### PR TITLE
Adds support for Oneboxes without Layouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Setup
     module Onebox
       module Engine
         class NameOnebox
-          include Engine
+          include LayoutSupport
           include HTML
 
           private
@@ -153,7 +153,7 @@ Setup
     # in lib/onebox/engine/engine.rb
     require_relative "engine/name_onebox"
     ```
-    
+
 Onebox currently has support for page, image, and video URLs from these sites:
 
   - Amazon

--- a/lib/onebox/engine.rb
+++ b/lib/onebox/engine.rb
@@ -13,17 +13,17 @@ module Onebox
     attr_reader :url
     attr_reader :cache
     attr_reader :timeout
-    attr_reader :layout
 
     def initialize(link, cache = nil, timeout = nil)
       @url = link
       @cache = cache || Onebox.defaults.cache
       @timeout = timeout || Onebox.defaults.timeout
-      @layout = Layout.new(self.class.template_name, record, @cache)
     end
 
+    # raises error if not defined in onebox engine. This is the output method for
+    # an engine.
     def to_html
-      layout.to_html
+      raise NoMethodError, "Engines need to implement this method"
     end
 
     private
@@ -65,14 +65,17 @@ module Onebox
         class_variable_set :@@matcher, Hexpress.new(&block).to_r
       end
 
-      # calculates handlebars template name for onebox using name of engine
-      def template_name
+      # calculates a name for onebox using the class name of engine
+      def onebox_name
         name.split("::").last.downcase.gsub(/onebox/, "")
       end
+
     end
   end
 end
 
+require_relative "layout_support"
+require_relative "iframe_support"
 require_relative "engine/open_graph"
 require_relative "engine/html"
 require_relative "engine/json"

--- a/lib/onebox/engine/amazon_onebox.rb
+++ b/lib/onebox/engine/amazon_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class AmazonOnebox
       include Engine
+      include LayoutSupport
       include HTML
 
       matches do

--- a/lib/onebox/engine/bliptv_onebox.rb
+++ b/lib/onebox/engine/bliptv_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class BliptvOnebox
       include Engine
+      include LayoutSupport
       include OpenGraph
 
       matches do

--- a/lib/onebox/engine/clikthrough_onebox.rb
+++ b/lib/onebox/engine/clikthrough_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class ClikThroughOnebox
       include Engine
+      include LayoutSupport
       include OpenGraph
 
       matches do

--- a/lib/onebox/engine/college_humor_onebox.rb
+++ b/lib/onebox/engine/college_humor_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class CollegeHumorOnebox
       include Engine
+      include LayoutSupport
       include OpenGraph
 
       matches do

--- a/lib/onebox/engine/dailymotion_onebox.rb
+++ b/lib/onebox/engine/dailymotion_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class DailymotionOnebox
       include Engine
+      include LayoutSupport
       include OpenGraph
 
       matches do

--- a/lib/onebox/engine/dotsub_onebox.rb
+++ b/lib/onebox/engine/dotsub_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class DotsubOnebox
       include Engine
+      include LayoutSupport
       include OpenGraph
 
       matches do

--- a/lib/onebox/engine/flickr_onebox.rb
+++ b/lib/onebox/engine/flickr_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class FlickrOnebox
       include Engine
+      include LayoutSupport
       include OpenGraph
 
       matches do

--- a/lib/onebox/engine/funny_or_die_onebox.rb
+++ b/lib/onebox/engine/funny_or_die_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class FunnyOrDieOnebox
       include Engine
+      include LayoutSupport
       include OpenGraph
 
       matches do

--- a/lib/onebox/engine/github_blob_onebox.rb
+++ b/lib/onebox/engine/github_blob_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class GithubBlobOnebox
       include Engine
+      include LayoutSupport
       include HTML
 
       matches do

--- a/lib/onebox/engine/github_commit_onebox.rb
+++ b/lib/onebox/engine/github_commit_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class GithubCommitOnebox
       include Engine
+      include LayoutSupport
       include JSON
 
       matches do

--- a/lib/onebox/engine/github_gist_onebox.rb
+++ b/lib/onebox/engine/github_gist_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class GithubGistOnebox
       include Engine
+      include LayoutSupport
       include JSON
 
       matches do

--- a/lib/onebox/engine/github_pullrequest_onebox.rb
+++ b/lib/onebox/engine/github_pullrequest_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class GithubPullRequestOnebox
       include Engine
+      include LayoutSupport
       include JSON
 
       matches do

--- a/lib/onebox/engine/google_play_app_onebox.rb
+++ b/lib/onebox/engine/google_play_app_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class GooglePlayAppOnebox
       include Engine
+      include LayoutSupport
       include HTML
 
       matches do

--- a/lib/onebox/engine/hulu_onebox.rb
+++ b/lib/onebox/engine/hulu_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class HuluOnebox
       include Engine
+      include LayoutSupport
       include OpenGraph
 
       matches do

--- a/lib/onebox/engine/imgur_image_onebox.rb
+++ b/lib/onebox/engine/imgur_image_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class ImgurImageOnebox
       include Engine
+      include LayoutSupport
       include HTML
 
       matches do

--- a/lib/onebox/engine/itunes_onebox.rb
+++ b/lib/onebox/engine/itunes_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class ItunesOnebox
       include Engine
+      include LayoutSupport
       include OpenGraph
 
       matches do

--- a/lib/onebox/engine/kinomap_onebox.rb
+++ b/lib/onebox/engine/kinomap_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class KinomapOnebox
       include Engine
+      include LayoutSupport
       include OpenGraph
 
       matches do

--- a/lib/onebox/engine/nfb_onebox.rb
+++ b/lib/onebox/engine/nfb_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class NFBOnebox
       include Engine
+      include LayoutSupport
       include OpenGraph
 
       matches do

--- a/lib/onebox/engine/qik_onebox.rb
+++ b/lib/onebox/engine/qik_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class QikOnebox
       include Engine
+      include LayoutSupport
       include HTML
 
       matches do

--- a/lib/onebox/engine/revision3_onebox.rb
+++ b/lib/onebox/engine/revision3_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class Revision3Onebox
       include Engine
+      include LayoutSupport
       include OpenGraph
 
       matches do

--- a/lib/onebox/engine/slideshare_onebox.rb
+++ b/lib/onebox/engine/slideshare_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class SlideshareOnebox
       include Engine
+      include LayoutSupport
       include OpenGraph
 
       matches do

--- a/lib/onebox/engine/smug_mug_onebox.rb
+++ b/lib/onebox/engine/smug_mug_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class SmugMugOnebox
       include Engine
+      include LayoutSupport
       include JSON
 
       matches do

--- a/lib/onebox/engine/sound_cloud_onebox.rb
+++ b/lib/onebox/engine/sound_cloud_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class SoundCloudOnebox
       include Engine
+      include LayoutSupport
       include OpenGraph
 
       matches do

--- a/lib/onebox/engine/spotify_onebox.rb
+++ b/lib/onebox/engine/spotify_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class SpotifyOnebox
       include Engine
+      include LayoutSupport
       include OpenGraph
 
       matches do

--- a/lib/onebox/engine/stack_exchange_onebox.rb
+++ b/lib/onebox/engine/stack_exchange_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class StackExchangeOnebox
       include Engine
+      include LayoutSupport
       include HTML
 
       matches do

--- a/lib/onebox/engine/ted_onebox.rb
+++ b/lib/onebox/engine/ted_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class TedOnebox
       include Engine
+      include LayoutSupport
       include OpenGraph
 
       matches do

--- a/lib/onebox/engine/twitter_onebox.rb
+++ b/lib/onebox/engine/twitter_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class TwitterOnebox
       include Engine
+      include LayoutSupport
       include HTML
 
       matches do

--- a/lib/onebox/engine/viddler_onebox.rb
+++ b/lib/onebox/engine/viddler_onebox.rb
@@ -2,6 +2,7 @@
   module Engine
     class ViddlerOnebox
       include Engine
+      include LayoutSupport
       include OpenGraph
 
       matches do

--- a/lib/onebox/engine/vimeo_onebox.rb
+++ b/lib/onebox/engine/vimeo_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class VimeoOnebox
       include Engine
+      include IFrameSupport
       include OpenGraph
 
       matches do
@@ -20,7 +21,7 @@ module Onebox
           title: raw.title,
           image: raw.images.first,
           description: raw.description,
-          video: raw.metadata[:video].first[:_value]
+          video: raw.metadata[:video].first
         }
       end
     end

--- a/lib/onebox/engine/wikipedia_onebox.rb
+++ b/lib/onebox/engine/wikipedia_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class WikipediaOnebox
       include Engine
+      include LayoutSupport
       include HTML
 
       matches do

--- a/lib/onebox/engine/yfrog_onebox.rb
+++ b/lib/onebox/engine/yfrog_onebox.rb
@@ -2,6 +2,7 @@ module Onebox
   module Engine
     class YfrogOnebox
       include Engine
+      include LayoutSupport
       include OpenGraph
 
       matches do

--- a/lib/onebox/iframe_support.rb
+++ b/lib/onebox/iframe_support.rb
@@ -1,0 +1,38 @@
+module Onebox
+  module IFrameSupport
+
+    # Generates the HTML for the iframe, complete with dimensions supplied from opengraph
+    def to_html
+      video = data[:video]
+      if video
+        video_url = video[:_value]
+
+        if video_url
+
+          html = "<iframe src=\"#{video_url}\" frameborder=\"0\" title=\"#{data[:title]}\""
+
+          append_attribute(:width, html, video)
+          append_attribute(:height, html, video)
+
+          html << "></iframe>"
+          return html
+        end
+      end
+
+      return ""
+    end
+
+
+    private
+
+    def append_attribute(attribute, html, video)
+      if video[attribute] &&
+         video[attribute].first &&
+         val = video[attribute].first[:_value]
+
+         html << " #{attribute.to_s}=\"#{val}\""
+      end
+    end
+
+  end
+end

--- a/lib/onebox/layout_support.rb
+++ b/lib/onebox/layout_support.rb
@@ -1,0 +1,13 @@
+module Onebox
+  module LayoutSupport
+
+    def layout
+      @layout ||= Layout.new(self.class.onebox_name, record, @cache)
+    end
+
+    def to_html
+      layout.to_html
+    end
+
+  end
+end

--- a/spec/lib/onebox/engine/github_pullrequest_onebox_spec.rb
+++ b/spec/lib/onebox/engine/github_pullrequest_onebox_spec.rb
@@ -4,7 +4,7 @@ describe Onebox::Engine::GithubPullRequestOnebox do
   before(:all) do
     @link = "https://github.com/discourse/discourse/pull/1253/"
     @uri = "https://api.github.com/repos/discourse/discourse/pulls/1253"
-    fake(@uri, response(described_class.template_name))
+    fake(@uri, response(described_class.onebox_name))
   end
 
   include_context "engines"

--- a/spec/lib/onebox/engine/vimeo_onebox_spec.rb
+++ b/spec/lib/onebox/engine/vimeo_onebox_spec.rb
@@ -9,16 +9,16 @@ describe Onebox::Engine::VimeoOnebox do
   it_behaves_like "an engine"
 
   describe "#to_html" do
-    it "includes still" do
-      expect(html).to include("443673159_1280.jpg")
+    it "includes iframe" do
+      expect(html).to include("iframe")
     end
 
-    it "includes description" do
-      expect(html).to include("To mark the launch of a new website for Hermann Miller furniture")
+    it "includes title" do
+      expect(html).to include("108 years of Herman Miller in 108 seconds")
     end
 
     it "includes embedded video link" do
-      expect(html).to include("http://vimeo.com/moogaloop.swf?clip_id=70437049")
+      expect(html).to include("ttp://vimeo.com/moogaloop.swf?clip_id=70437049")
     end
   end
 end

--- a/spec/lib/onebox/engine_spec.rb
+++ b/spec/lib/onebox/engine_spec.rb
@@ -4,20 +4,23 @@ describe Onebox::Engine do
   class OneboxEngineExample
     include Onebox::Engine
 
+    def to_html
+      "Hello #{link}"
+    end
+
     def data
       { foo: raw[:key], url: @url }
     end
 
     def raw
       { key: "value" }
-    end      
+    end
   end
 
-  before(:each) { Onebox::View.any_instance.stub(:template) { %|this shold be a template| } }
+  describe "#link" do
+    before { Onebox::View.any_instance.stub(:template) { %|this shold be a template| } }
 
-  describe "#to_html" do
-    pending
-    it "doesn't allow XSS injection" do
+    it "escapes `link`" do
       html = OneboxEngineExample.new(%|http://foo.com" onscript="alert('foo')|).to_html
       expect(html).not_to include(%|onscript="alert('foo')|)
     end
@@ -71,21 +74,23 @@ describe Onebox::Engine do
     end
   end
 
-  describe ".template_name" do
-    module ScopeForTemplateName
-      class TemplateNameOnebox
-        include Onebox::Engine
-      end
-    end
+end
 
-    let(:template_name) { ScopeForTemplateName::TemplateNameOnebox.template_name }
 
-    it "should not include the scope" do
-      expect(template_name).not_to include("ScopeForTemplateName", "scopefortemplatename")
+describe ".onebox_name" do
+  module ScopeForTemplateName
+    class TemplateNameOnebox
+      include Onebox::Engine
     end
+  end
 
-    it "should not include the word Onebox" do
-      expect(template_name).not_to include("onebox", "Onebox")
-    end
+  let(:onebox_name) { ScopeForTemplateName::TemplateNameOnebox.onebox_name }
+
+  it "should not include the scope" do
+    expect(onebox_name).not_to include("ScopeForTemplateName", "scopefortemplatename")
+  end
+
+  it "should not include the word Onebox" do
+    expect(onebox_name).not_to include("onebox", "Onebox")
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ end
 
 shared_context "engines" do
   before(:all) do
-    fake(@uri || @link, response(described_class.template_name))
+    fake(@uri || @link, response(described_class.onebox_name))
     @onebox = described_class.new(@link)
     @html = @onebox.to_html
     @data = @onebox.send(:data)
@@ -65,10 +65,12 @@ shared_examples_for "an engine" do
       expect(data[:domain]).not_to be_nil
     end
   end
+end
 
+shared_examples_for "a layout engine" do
   describe "#to_html" do
     it "includes subname" do
-      expect(html).to include(%|<aside class="onebox #{described_class.template_name}">|)
+      expect(html).to include(%|<aside class="onebox #{described_class.onebox_name}">|)
     end
 
     it "includes title" do

--- a/templates/vimeo.mustache
+++ b/templates/vimeo.mustache
@@ -1,5 +1,0 @@
-
-
-<img src="{{image}}" />
-{{video}}
-<p>{{description}}</p>


### PR DESCRIPTION
Currently the onebox gem assumes you want to use a Mustache layout for your onebox result. While most of the time this is true, there are certain kinds of embeds where it doesn't make sense. This pull request focuses on the onebox for Vimeo as an example, where you'd rather just embed an `iframe` than render a layout.

This pull request does the following:
- Extracts the Layout capability to a mixin, `Onebox::LayoutSupport`
- Adds a new capability, 'Onebox::IFrameSupport` for rendering an iframe from opengraph results
- It renames `template_name` in the `Engine` to be `onebox_name` since we won't always have templates
- I added the dependencies for `_onebox.rb` classes (`html`, `open_graph`, etc) to the classes themselves.

Let me know how it looks!
