### PR TITLE
Update reference to gemspec in Gemfile to drop discourse-

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in discourse-onebox.gemspec
+# Specify your gem's dependencies in onebox.gemspec
 gemspec

--- a/onebox.gemspec
+++ b/onebox.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["holla@jzeta.com", "vyki.englert@gmail.com"]
   spec.description   = %q{A gem for turning URLs into previews.}
   spec.summary       = spec.description
-  spec.homepage      = "http://github.com/dysania/onebox"
+  spec.homepage      = "https://github.com/dysania/onebox"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)


### PR DESCRIPTION
Updates spec.homepage to SSL always version of GitHub repo location

Looks like the Gemfile comment slipped through. Unless it's supposed to be `discourse-onebox`
