### PR TITLE
Don't use CGI::TABLE_FOR_ESCAPE_HTML__.

### DIFF
--- a/lib/onebox/engine.rb
+++ b/lib/onebox/engine.rb
@@ -59,7 +59,13 @@ module Onebox
     end
 
     def link
-      @url.gsub(/['\"<>]/, CGI::TABLE_FOR_ESCAPE_HTML__)
+      @url.gsub(/['\"<>]/, {
+        "'" => '&#39;',
+        '&' => '&amp;',
+        '"' => '&quot;',
+        '<' => '&lt;',
+        '>' => '&gt;',
+      })
     end
 
     module ClassMethods


### PR DESCRIPTION
`CGI::TABLE_FOR_ESCAPE_HTML__` is `CGI::Util::TABLE_FOR_ESCAPE_HTML__` on Ruby 2.1.0 (and also 2.0?). 

To avoid issues I replaced it with the actual value.
