### PR TITLE
Add wistia.com to whitelist

### DIFF
--- a/lib/onebox/engine/whitelisted_generic_onebox.rb
+++ b/lib/onebox/engine/whitelisted_generic_onebox.rb
@@ -102,13 +102,15 @@ module Onebox
           wikia.com
           wikihow.com
           wired.com
+          wistia.com
+          wi.st
           wonderhowto.com
           wsj.com
           youtube.com
           zappos.com
           zillow.com)
 			end
-				
+
 			def self.===(other)
 				if other.kind_of?(URI)
 					!!whitelist.find {|h| %r((^|\.)#{Regexp.escape(h)}$).match(other.host) }


### PR DESCRIPTION
Add wistia.com as a whitelisted site. Example video: http://dwolla-1.wistia.com/medias/3nucsl9dva
