### PR TITLE
Youtube onebox enhancements

### DIFF
--- a/lib/onebox/engine/youtube_onebox.rb
+++ b/lib/onebox/engine/youtube_onebox.rb
@@ -14,6 +14,14 @@ module Onebox
         match && match[3]
       end
 
+      def placeholder_html
+        if video_id
+          "<img src='http://i1.ytimg.com/vi/#{video_id}/hqdefault.jpg' width='480' height='270'>"
+        else
+          to_html
+        end
+      end
+
       def to_html
         if video_id
           # Avoid making HTTP requests if we are able to get the video ID from the

--- a/spec/lib/onebox/engine/youtube_onebox_spec.rb
+++ b/spec/lib/onebox/engine/youtube_onebox_spec.rb
@@ -6,22 +6,26 @@ describe Onebox::Engine::YoutubeOnebox do
     fake("http://www.youtube.com/oembed?format=json&url=http%3A%2F%2Fwww.youtube.com%2Fwatch%3Fv%3D21Lk4YiASMo", response("youtube-json"))
   end
 
-  it "should add wmode=opaque" do
+  it "adds wmode=opaque" do
     Onebox.preview('https://www.youtube.com/watch?v=21Lk4YiASMo').to_s.should match(/wmode=opaque/)
   end
 
-  it "should rewrite URLs to be agnostic" do
+  it "rewrites URLs to be agnostic" do
     Onebox.preview('https://www.youtube.com/watch?v=21Lk4YiASMo').to_s.should match(/"\/\//)
   end
 
-  it "should not make HTTP requests unless necessary" do
+  it "does not make HTTP requests unless necessary" do
     # We haven't defined any fixture for requests associated with this ID, so if
     # any HTTP requests are made fakeweb will complain and the test will fail.
     Onebox.preview('http://www.youtube.com/watch?v=q39Ce3zDScI').to_s
   end
 
-  it "should not fail if we cannot get the video ID from the URL" do
+  it "does not fail if we cannot get the video ID from the URL" do
     Onebox.preview('http://www.youtube.com/watch?feature=player_embedded&v=21Lk4YiASMo').to_s.should match(/embed/)
+  end
+
+  it "returns an image as the placeholder" do
+    Onebox.preview('https://www.youtube.com/watch?v=21Lk4YiASMo').placeholder_html.should match(/<img/)
   end
 end
 


### PR DESCRIPTION
I've had users complain about having trouble making posts with multiple videos embedded, which turned out to be gateway timeouts caused by the two HTTP requests that need to be made for every video taking too long to finish.

Since the Youtube embed URL is known it makes sense to try to extract the video ID and generate the HTML directly without making HTTP requests, which is what I've done. If the user posts an unknown URL format we fall back to making HTTP requests to figure out the embed code.

I've also added a `placeholder_html` method that will return a thumbnail for the composer.
