### PR TITLE
Added lessonplanet.com to list of generic oneboxes

### DIFF
--- a/lib/onebox/engine/whitelisted_generic_onebox.rb
+++ b/lib/onebox/engine/whitelisted_generic_onebox.rb
@@ -64,6 +64,7 @@ module Onebox
           khanacademy.org
           kickstarter.com
           kinomap.com
+          lessonplanet.com
           mashable.com
           mlb.com
           myspace.com


### PR DESCRIPTION
Lesson Planet reviews Educational resources for Teachers. Here is an example page to be onebox'd.

http://www.lessonplanet.com/teachers/app-dragonbox-algebra
