### PR TITLE
Allow coveralls reporting

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,7 +13,7 @@ require_relative "support/html_spec_helper"
 
 RSpec.configure do |config|
   config.before(:all) do
-    FakeWeb.allow_net_connect = false
+    FakeWeb.allow_net_connect = %r[^https?://coveralls.io]
   end
   config.include HTMLSpecHelper
 end


### PR DESCRIPTION
The coveralls spec hasn't been updated since 4th of Jan, travis has errors like
these: https://travis-ci.org/discourse/onebox/builds/22741169#L406

Fakeweb has been blocking the Coveralls client from updating.
