### PR TITLE
Updates the GitHub url in the readme and gemspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ onebox
 
   - [![Gem Version](https://badge.fury.io/rb/onebox.png)](https://rubygems.org/gems/onebox)
   - [![Code Climate](https://codeclimate.com/github/dysania/onebox.png)](https://codeclimate.com/github/dysania/onebox)
-  - [![Build Status](https://travis-ci.org/dysania/onebox.png)](https://travis-ci.org/dysania/onebox)
-  - [![Dependency Status](https://gemnasium.com/dysania/onebox.png)](https://gemnasium.com/dysania/onebox)
+  - [![Build Status](https://travis-ci.org/discourse/onebox.png)](https://travis-ci.org/discourse/onebox)
+  - [![Dependency Status](https://gemnasium.com/discourse/onebox.png)](https://gemnasium.com/discourse/onebox)
 
 
 Onebox is a library for turning media URLs into simple HTML previews of the resource.

--- a/onebox.gemspec
+++ b/onebox.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["holla@jzeta.com", "vyki.englert@gmail.com", "robin.ward@gmail.com"]
   spec.description   = %q{A gem for turning URLs into previews.}
   spec.summary       = spec.description
-  spec.homepage      = "https://github.com/dysania/onebox"
+  spec.homepage      = "https://github.com/discourse/onebox"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files`.split($/)


### PR DESCRIPTION
The Travis build status image in the readme actually breaks because of the incorrect url, updated the others for consistency.

The Code climate account should probably be renamed as well so everything communicates the discourse url, but whoever has the permissions to do so should do that.
