### PR TITLE
Removes Coveralls setup from spec helper

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,3 @@
-require "coveralls"
-Coveralls.wear! do
-  add_filter "/spec/"
-end
-
 require "rspec"
 require "pry"
 require "fakeweb"


### PR DESCRIPTION
Coveralls was removed in 95a13f4, but not al references were removed causing the spec to fail
