### PR TITLE
Make dropbox image matching more strict

### DIFF
--- a/lib/onebox/engine/image_onebox.rb
+++ b/lib/onebox/engine/image_onebox.rb
@@ -7,7 +7,7 @@ module Onebox
 
       def to_html
         # Fix Dropbox image links
-        if /^https:\/\/www.dropbox.com/.match @url
+        if /^https:\/\/www.dropbox.com\/s\//.match @url
           @url.gsub!("https://www.dropbox.com","https://dl.dropboxusercontent.com")
         end
 


### PR DESCRIPTION
Example URL:

https://www.dropbox.com/s/wixkhuf9mo8i5lw/Screenshot%202014-06-20%2008.00.57.png
