### PR TITLE
FIX: support time parameter for youtube desktop and mobile url

### DIFF
--- a/lib/onebox/engine/youtube_onebox.rb
+++ b/lib/onebox/engine/youtube_onebox.rb
@@ -11,7 +11,7 @@ module Onebox
       # * http://youtu.be/afyK1HSFfgw
       # * https://www.youtube.com/embed/vsF0K3Ou1v0
       def video_id
-        match = @url.match(/^https?:\/\/(?:www\.)?(?:m\.)?(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([a-zA-Z0-9_\-]{11})(?:\?.*)?$/)
+        match = @url.match(/^https?:\/\/(?:www\.)?(?:m\.)?(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([a-zA-Z0-9_\-]{11})(?:[#&\?]t=(([0-9]+[smh]?)+))?$/)
         match && match[1]
       end
 


### PR DESCRIPTION
Support time parameter for YouTube desktop and mobile url, example links:
- https://m.youtube.com/watch?v=Fk2bUvrv-Uc&t=2m30s
- http://www.youtube.com/watch?v=Fk2bUvrv-Uc&t=2m30s

also see -- https://meta.discourse.org/t/ytlight-a-lightweight-youtube-oneboxer/12455/22?u=techapj
