### PR TITLE
Fix PubMed URLs

### DIFF
--- a/lib/onebox/engine/pubmed_onebox.rb
+++ b/lib/onebox/engine/pubmed_onebox.rb
@@ -9,7 +9,7 @@ module Onebox
       private
 
       def get_xml
-        doc = Nokogiri::XML(open(@url + "?report=xml&format=text"))
+        doc = Nokogiri::XML(open(URI.join(@url, "?report=xml&format=text")))
         pre = doc.xpath("//pre")
         Nokogiri::XML("<root>" + pre.text + "</root>")
       end


### PR DESCRIPTION
When an URL from PubMed contains a query string like `?dopt=Abstract`, we need to remove it before adding the new one requesting the XML format.
