### PR TITLE
FIX: expand t.co links to show original link

### DIFF
--- a/lib/onebox/engine/twitter_status_onebox.rb
+++ b/lib/onebox/engine/twitter_status_onebox.rb
@@ -35,7 +35,7 @@ module Onebox
         if raw.html?
           raw.css(".tweet-text")[0].inner_text
         else
-          access(:text)
+          client.prettify_tweet(raw)
         end
       end
 

--- a/lib/onebox/version.rb
+++ b/lib/onebox/version.rb
@@ -1,3 +1,3 @@
 module Onebox
-  VERSION = "1.4.8"
+  VERSION = "1.4.9"
 end

--- a/spec/lib/onebox/engine/twitter_status_onebox_spec.rb
+++ b/spec/lib/onebox/engine/twitter_status_onebox_spec.rb
@@ -10,6 +10,10 @@ describe Onebox::Engine::TwitterStatusOnebox do
       expect(html).to include("I'm a sucker for pledges.")
     end
 
+    it "includes link" do
+      expect(html).to include("http://www.peers.org/action/peers-pledgea")
+    end
+
     it "includes timestamp" do
       pending
       expect(html).to include("6:59 PM - 1 Aug 13")
@@ -88,6 +92,9 @@ describe Onebox::Engine::TwitterStatusOnebox do
           possibly_sensitive: false,
           lang: "en"
         }
+      end
+      @twitter_client.stub("prettify_tweet") do
+        "I'm a sucker for pledges.  <a href='https://twitter.com/Peers' target='_blank'>@Peers</a> Pledge <a href='https://twitter.com/search?q=%23sharingeconomy' target='_blank'>#sharingeconomy</a> <a target='_blank' href='http://www.peers.org/action/peers-pledgea/'>peers.org/action/peers-p…</a>"
       end
       Onebox.options = { twitter_client: @twitter_client }
     end


### PR DESCRIPTION
Example:

![screen shot 2014-08-29 at 19 43 48](https://cloud.githubusercontent.com/assets/5732281/4092914/f48f564c-2f96-11e4-9c43-daa4384158a8.png)

Notice `t.co` link expands to `meta.discourse.org/t/how-to-updat…`
