### PR TITLE
optimization: eliminate a double call to the method url() and store result in a local variable

### DIFF
--- a/lib/onebox/engine.rb
+++ b/lib/onebox/engine.rb
@@ -41,8 +41,9 @@ module Onebox
     private
 
     def record
-      result = cache.fetch(url) { data }
-      cache[url] = result if cache.respond_to?(:key?)
+      url_result = url
+      result = cache.fetch(url_result) { data }
+      cache[url_result] = result if cache.respond_to?(:key?)
       result
     end
 


### PR DESCRIPTION
The url() method when defined in an engine class typically contains logic and dynamic string allocation.
and it annoyed me.

may be url_result is not the best name but that is the best I came up with.
