### PR TITLE
add options for each engine. extracted from Onebox.options based on class name

### DIFF
--- a/lib/onebox/engine.rb
+++ b/lib/onebox/engine.rb
@@ -13,8 +13,29 @@ module Onebox
     attr_reader :url
     attr_reader :cache
     attr_reader :timeout
+    
+    DEFUALT = {}
+    def options
+      @options
+    end
+    
+    def options=(opt)
+      return @options if opt.nil? #make sure options provided
+      if opt.instance_of? OpenStruct
+        @options = @options.merge(opt.to_h)   
+      else
+       @options =  @options.merge(opt)
+      end
+      @options
+    end
+    
 
     def initialize(link, cache = nil, timeout = nil)
+      
+      @options = DEFUALT
+      class_name = self.class.name.split("::").last.to_s
+      self.options = Onebox.options[class_name] || {} #Set the engine options extracted from global options.
+      
       @url = link
       @cache = cache || Onebox.options.cache
       @timeout = timeout || Onebox.options.timeout


### PR DESCRIPTION
allow each engine to access its own options 
For example to set options for the engine github_blob_onebox.rb 

``` ruby
Onebox.options = {
  GithubBlobOnebox => {:SHOW_LINE_NUMBER => true}
}
```

then from within the engine options can be accessed 

``` ruby
#get the engine option
self.options[:SHOW_LINE_NUMBER]

```
