### PR TITLE
Genric Onebox - add cookie support for request

### DIFF
--- a/lib/onebox/engine/whitelisted_generic_onebox.rb
+++ b/lib/onebox/engine/whitelisted_generic_onebox.rb
@@ -76,6 +76,7 @@ module Onebox
           mlb.com
           myspace.com
           nba.com
+          nytimes.com
           npr.org
           photobucket.com
           pinterest.com


### PR DESCRIPTION
Add cookie support to generic onebox request.
will allow completing a request for website that cookies are mandatory such as the nytimes.com

I have added nytimes.com for testing so if you don't want it by default let me know and I will remove it.
![image](https://cloud.githubusercontent.com/assets/8693091/4583064/40047d2e-4fee-11e4-9eca-a544d2cdd6f2.png)
