### PR TITLE
Support fragment(hash)-based URIs

### DIFF
--- a/lib/onebox/matcher.rb
+++ b/lib/onebox/matcher.rb
@@ -13,8 +13,9 @@ module Onebox
     def oneboxed
       uri = URI(@url)
 
-      # A onebox needs a path or query string to be considered
+      # A onebox needs a path, query or fragment string to be considered
       return if (uri.query.nil? || uri.query.size == 0) &&
+                (uri.fragment.nil? || uri.fragment.size == 0) &&
                 (uri.path.size == 0 || uri.path == "/")
 
       ordered_engines.select do |engine|

--- a/spec/lib/onebox/matcher_spec.rb
+++ b/spec/lib/onebox/matcher_spec.rb
@@ -39,5 +39,16 @@ describe Onebox::Matcher do
         matcher.oneboxed.should_not be_nil
       end
     end
+
+    describe "without a path but has a fragment string" do
+      let(:url) { "http://party.time.made.up-url.com/#article_id=1234" }
+      let(:matcher) { Onebox::Matcher.new(url) }
+
+      it "it finds an engine" do
+        matcher.stubs(:ordered_engines).returns([TestEngine])
+        matcher.oneboxed.should_not be_nil
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This PR introduces support for purely hash-based URLs, which enables oneboxing of URLs like this one:
http://www.openstreetmap.org/#map=12/48.8557/2.3186

Without this change  plugins like [discourse-openstreetmap](https://github.com/lidel/discourse-openstreetmap) are not being triggered.
