### PR TITLE
Remove Status tags/indications on GH issues

### DIFF
--- a/lib/onebox/engine/github_issue_onebox.rb
+++ b/lib/onebox/engine/github_issue_onebox.rb
@@ -8,7 +8,7 @@ module Onebox
       matches_regexp Regexp.new("^http(?:s)?:\/\/(?:www\.)?(?:(?:\w)+\.)?github\.com\/(?<org>.+)\/(?<repo>.+)\/issues\/([[:digit:]]+)")
 
       def url
-        m = match 
+        m = match
         "https://api.github.com/repos/#{m["org"]}/#{m["repo"]}/issues/#{m["item_id"]}"
       end
 
@@ -19,11 +19,11 @@ module Onebox
       end
 
       def data
-        
+
         @raw ||= ::MultiJson.load(open(url,"Accept"=>"application/vnd.github.v3.text+json",:read_timeout=>timeout )) #custom Accept header so we can get body as text.
         body_text=  @raw["body_text"]
-      
-        
+
+
         content_words = body_text.gsub("\n\n","\n").gsub("\n","<br>").split(" ") #one pass of removing double newline, then we change \n to <br> and later on we revert it back to \n this is a workaround to avoid losing newlines after we join it back.
         max_words = 20
         short_content =  content_words[0..max_words].join(" ")
@@ -35,8 +35,6 @@ module Onebox
                    content:short_content.gsub("<br>","\n"),
                    labels: @raw["labels"],
                    user: @raw['user'],
-                   status: @raw['state'],
-                   status_color:  status_color[@raw['state']] || "#cfcfcf",
                    created_at: @raw['created_at'].split("T")[0], #get only date for now
                    closed_at: (@raw['closed_at'].nil? ? "" : @raw['closed_at'].split("T")[0] ) ,
                    closed_by: @raw['closed_by'],

--- a/templates/githubissue.mustache
+++ b/templates/githubissue.mustache
@@ -5,16 +5,13 @@
 <h4><a href="{{link}}" target="_blank">{{title}}</a></h4>
 
 <div class="date" style="margin-top:10px;">
-	<div class="status">
-	<span style="background-color: {{status_color}};padding: 2px;border-radius: 4px;color: #fff;">{{status}}</span>
-	</div>
 	<div class="user" style="margin-top:10px;">
-	opened by <a href="{{user.html_url}}" target="_blank">{{user.login}}</a> 
+	opened by <a href="{{user.html_url}}" target="_blank">{{user.login}}</a>
 	on <a href="{{link}}" target="_blank">{{created_at}}</a>
 	</div>
 	<div class="user">
 	{{#closed_by}}
-	closed by <a href="{{html_url}}" target="_blank">{{login}}</a> 
+	closed by <a href="{{html_url}}" target="_blank">{{login}}</a>
 	on <a href="{{link}}" target="_blank">{{closed_at}}</a>
 	{{/closed_by}}
 	</div>


### PR DESCRIPTION
See #264, removes the status (open/closed) text on Github Issues as there is no way to update this status.