### PR TITLE
Put tweet body in a tag of its own.

### DIFF
--- a/templates/twitterstatus.mustache
+++ b/templates/twitterstatus.mustache
@@ -5,7 +5,7 @@
   </a>
 </h4>
 
-{{{tweet}}}
+<p>{{{tweet}}}</p>
 
 <div class='date'>
   <a href="{{link}}" target="_blank">{{timestamp}}</a>


### PR DESCRIPTION
This will allow a css rule to set `white-space: pre-wrap;` on just the tweet text, displaying it correctly.