### PR TITLE
Add support for Google Maps with www.google URLs

### DIFF
--- a/lib/onebox/engine/classic_google_maps_onebox.rb
+++ b/lib/onebox/engine/classic_google_maps_onebox.rb
@@ -4,21 +4,33 @@ module Onebox
       include Engine
       include LayoutSupport
 
-      matches_regexp /^(https?:)?\/\/(maps\.google\.[\w.]{2,}|goo\.gl)\/maps?.+$/
+      matches_regexp /^(https?:)?\/\/((maps|www)\.google\.[\w.]{2,}|goo\.gl)\/maps?.+$/
 
       def url
-        @url = get_long_url if @url.include?("//goo.gl/maps/") 
+        @url = get_long_url if @url.include?("//goo.gl/maps/")
+        @url = get_canonical_url if @url.include?("www.google")
         @url
       end
 
       def to_html
-        "<iframe src='#{url}&output=embed' width='690px' height='400px' frameborder='0' style='border:0'></iframe>" 
+        "<iframe src='#{url}&output=embed' width='690px' height='400px' frameborder='0' style='border:0'></iframe>"
       end
 
-      private 
+      private
 
       def data
         {link: url, title: url}
+      end
+
+      def get_canonical_url
+        uri = URI(@url)
+        http = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https')
+        http.open_timeout = timeout
+        http.read_timeout = timeout
+        response = http.head(uri.path)
+        response["Location"].sub(/&?output=classic/, '') if response.code == "302"
+      rescue
+        @url
       end
 
       def get_long_url

--- a/spec/lib/onebox/engine/classic_google_maps_onebox_spec.rb
+++ b/spec/lib/onebox/engine/classic_google_maps_onebox_spec.rb
@@ -25,4 +25,14 @@ describe Onebox::Engine::ClassicGoogleMapsOnebox do
       expect(onebox.url).to eq(long_url)
     end
   end
+
+  describe 'www form url' do
+    let(:embed_url) { "https://maps.google.de/maps?t=h&ll=48.398499,9.992333&spn=0.0038338,0.0056322&dg=ntvb&output=embed" }
+
+    it "retrieves the canonical url" do
+      onebox = described_class.new("https://www.google.de/maps/@48.3932366,9.992333,663a,20y,41.43t/data=!3m1!1e3")
+      onebox.expects(:get_canonical_url).once.returns(embed_url)
+      expect(onebox.url).to eq(embed_url)
+    end
+  end
 end


### PR DESCRIPTION
See discussion at [Discourse meta](https://meta.discourse.org/t/can-google-maps-be-embedded-into-topics/11146/32?u=elberet).

URLs of the form `https://www.google.de/maps/...` are converted iframe-embeddable URLs by looking up canonical URL and removing `&output=classic` from query parameters.