### PR TITLE
Add gfycat.com to default whitelist

### DIFF
--- a/lib/onebox/engine/whitelisted_generic_onebox.rb
+++ b/lib/onebox/engine/whitelisted_generic_onebox.rb
@@ -54,6 +54,7 @@ module Onebox
           forbes.com
           foxnews.com
           funnyordie.com
+          gfycat.com
           groupon.com
           howtogeek.com
           huffingtonpost.com
@@ -130,7 +131,7 @@ module Onebox
       # include the entire page HTML. However for some providers like Imgur it allows us
       # to return gifv and galleries.
       def self.default_html_providers
-        ['Imgur', 'Meetup']
+        ['Imgur', 'Meetup', 'Gfycat']
       end
 
       def self.html_providers


### PR DESCRIPTION
So gfycat.com links will embed the mp4 and/or gif properly.