### PR TITLE
FIX: disable google map scroll by default

### DIFF
--- a/lib/onebox/engine/classic_google_maps_onebox.rb
+++ b/lib/onebox/engine/classic_google_maps_onebox.rb
@@ -11,7 +11,7 @@ module Onebox
       end
 
       def to_html
-        "<iframe src=\"#{link}\" width=\"690px\" height=\"400px\" frameborder=\"0\" style=\"border:0\"></iframe>"
+        "<div style=\"background:transparent;position:relative;width:690px;height:400px;top:400px;margin-top:-400px;\" onClick=\"style.pointerEvents='none'\"></div> <iframe src=\"#{link}\" width=\"690px\" height=\"400px\" frameborder=\"0\" style=\"border:0\"></iframe>"
       end
 
       def placeholder_html


### PR DESCRIPTION
[Meta topic](https://meta.discourse.org/t/disable-map-scroll-by-default/26623?u=techapj).

Uses [this solution](http://stackoverflow.com/a/22567753) to disable scroll on map by default. Clicking anywhere on map will enable scroll again.