### PR TITLE
FIX: flickr user profile

### DIFF
--- a/lib/onebox/engine/whitelisted_generic_onebox.rb
+++ b/lib/onebox/engine/whitelisted_generic_onebox.rb
@@ -180,7 +180,7 @@ module Onebox
 
       # Generates the HTML for the embedded content
       def photo_type?
-        data[:type] =~ /photo/ || data[:type] =~ /image/
+        ( (data[:type] =~ /photo/ || data[:type] =~ /image/) && data[:type] !~ /photostream/ )
       end
 
       def article_type?


### PR DESCRIPTION
The `og:type` for `https://www.flickr.com/photos/steevithak` is `flickr_photos:photostream`, so the current code is detecting the URL as image type, instead of user profile.

Example:

![screen shot 2015-03-25 at 00 41 46](https://cloud.githubusercontent.com/assets/5732281/6810821/87a570f2-d289-11e4-872c-95a4d96d2133.png)