### PR TITLE
FIX: use oEmbed for kickstarter

### DIFF
--- a/lib/onebox/engine/standard_embed.rb
+++ b/lib/onebox/engine/standard_embed.rb
@@ -20,6 +20,7 @@ module Onebox
 
       # Some oembed providers (like meetup.com) don't provide links to themselves
       add_oembed_provider /www\.meetup\.com\//, 'http://api.meetup.com/oembed'
+      add_oembed_provider /www\.kickstarter\.com\//, 'https://www.kickstarter.com/services/oembed'
 
       # Sites that work better with OpenGraph
       add_opengraph_provider /gfycat\.com\//


### PR DESCRIPTION
[Issue reported here.](https://meta.discourse.org/t/oneboxing-a-kickstarter-page-with-a-video-shows-just-the-video/21473/5?u=techapj)

Example:

![kickstarter](https://cloud.githubusercontent.com/assets/5732281/6964192/6b3eff00-d964-11e4-9e08-341c41389ddc.png)
