### PR TITLE
FIX: embedding ted talks was broken

### DIFF
--- a/lib/onebox/engine/standard_embed.rb
+++ b/lib/onebox/engine/standard_embed.rb
@@ -21,6 +21,7 @@ module Onebox
       # Some oembed providers (like meetup.com) don't provide links to themselves
       add_oembed_provider /www\.meetup\.com\//, 'http://api.meetup.com/oembed'
       add_oembed_provider /www\.kickstarter\.com\//, 'https://www.kickstarter.com/services/oembed'
+      add_oembed_provider /www\.ted\.com\//, 'http://www.ted.com/services/v1/oembed.json'
 
       # Sites that work better with OpenGraph
       add_opengraph_provider /gfycat\.com\//


### PR DESCRIPTION
Example:

![screen shot 2015-04-02 at 18 27 20](https://cloud.githubusercontent.com/assets/5732281/6964413/8d381bf8-d966-11e4-8e44-090cc12ab566.png)
