### PR TITLE
FIX: allow hidden but embeddable vimeo videos to display preview

### DIFF
--- a/lib/onebox/engine/standard_embed.rb
+++ b/lib/onebox/engine/standard_embed.rb
@@ -22,6 +22,7 @@ module Onebox
       add_oembed_provider /www\.meetup\.com\//, 'http://api.meetup.com/oembed'
       add_oembed_provider /www\.kickstarter\.com\//, 'https://www.kickstarter.com/services/oembed'
       add_oembed_provider /www\.ted\.com\//, 'http://www.ted.com/services/v1/oembed.json'
+      add_oembed_provider /(.*\.)?vimeo\.com\//, 'http://vimeo.com/api/oembed.json'
 
       # Sites that work better with OpenGraph
       add_opengraph_provider /gfycat\.com\//


### PR DESCRIPTION
Vimeo videos that are embeddable but hidden from Vimeos search do not contain
an oembed url, despite this being available. The endpoint is taken from iframely:

https://github.com/itteco/iframely/blob/master/lib/plugins/system/oembed/providers.json#L42