### PR TITLE
FIX: fetch YouTube video title via oEmbed

### DIFF
--- a/lib/onebox/engine/youtube_onebox.rb
+++ b/lib/onebox/engine/youtube_onebox.rb
@@ -57,6 +57,14 @@ module Onebox
         html
       end
 
+      def video_title
+        yt_oembed_url = "http://www.youtube.com/oembed?format=json&url=http://www.youtube.com/watch?v=#{video_id.split('?')[0]}"
+        yt_oembed_data = Onebox::Helpers.symbolize_keys(::MultiJson.load(Onebox::Helpers.fetch_response(yt_oembed_url).body))
+        yt_oembed_data[:title]
+      rescue
+        return nil
+      end
+
       # Regex to parse strings like "1h3m2s". Also accepts bare numbers (which are seconds).
       TIMESTR_REGEX = /(\d+h)?(\d+m)?(\d+s?)?/
 

--- a/onebox.gemspec
+++ b/onebox.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_runtime_dependency 'multi_json', '~> 1.11'
-  spec.add_runtime_dependency 'mustache', '~> 1.0'
+  spec.add_runtime_dependency 'mustache'
   spec.add_runtime_dependency 'nokogiri', '~> 1.6.6'
   spec.add_runtime_dependency 'moneta', '~> 0.8'
 


### PR DESCRIPTION
Reported here: https://meta.discourse.org/t/embedded-youtube-videos-url-always-showing-https-youtube-com-devicesupport/28415?u=techapj

Also merge: https://github.com/discourse/discourse/pull/3437