### PR TITLE
allow custom load paths for templates other than _layout

### DIFF
--- a/lib/onebox/layout.rb
+++ b/lib/onebox/layout.rb
@@ -1,5 +1,9 @@
+require_relative "template_support"
+
 module Onebox
   class Layout < Mustache
+    include TemplateSupport
+
     VERSION = "1.0.0"
 
     attr_reader :cache
@@ -33,13 +37,6 @@ module Onebox
       @uri = URI(link)
     end
 
-    def load_paths
-      Onebox.options.load_paths.select(&method(:template?))
-    end
-
-    def template?(path)
-      File.exist?(File.join(path, "#{template_name}.#{template_extension}"))
-    end
 
     def checksum
       @md5.hexdigest("#{VERSION}:#{link}")

--- a/lib/onebox/template_support.rb
+++ b/lib/onebox/template_support.rb
@@ -1,0 +1,11 @@
+module Onebox
+  module TemplateSupport
+    def load_paths
+      Onebox.options.load_paths.select(&method(:template?))
+    end
+
+    def template?(path)
+      File.exist?(File.join(path, "#{template_name}.#{template_extension}"))
+    end
+  end
+end

--- a/lib/onebox/view.rb
+++ b/lib/onebox/view.rb
@@ -1,12 +1,15 @@
+require_relative "template_support"
+
 module Onebox
   class View < Mustache
-    attr_reader :record
+    include TemplateSupport
 
-    self.template_path = Onebox.options.load_paths.last
+    attr_reader :record
 
     def initialize(name, record)
       @record = record
       self.template_name = name
+      self.template_path = load_paths.last
     end
 
     def to_html


### PR DESCRIPTION
While trying to load custom templates I found that trying to load anything other than a custom `_layout` was not working, this is because right now the `View`s `template_path` is being set at require time, which is before custom paths are added. I noticed that there was already a nice way to handle falling back to the default templates in `Layout` so I just moved that out into a module and reused it here.

I hope this approach is OK, if you have a better idea please do let me know.