### PR TITLE
Adding Onebox#check method, solving #154

### DIFF
--- a/lib/onebox.rb
+++ b/lib/onebox.rb
@@ -23,6 +23,10 @@ module Onebox
     Preview.new(url, options)
   end
 
+  def self.check(url, options = Onebox.options)
+    StatusCheck.new(url, options)
+  end
+
   def self.options
     OpenStruct.new(@@options)
   end
@@ -39,6 +43,7 @@ end
 
 require_relative "onebox/version"
 require_relative "onebox/preview"
+require_relative "onebox/status_check"
 require_relative "onebox/matcher"
 require_relative "onebox/engine"
 require_relative "onebox/layout"

--- a/lib/onebox/status_check.rb
+++ b/lib/onebox/status_check.rb
@@ -1,0 +1,44 @@
+module Onebox
+  class StatusCheck
+    def initialize(url, options = Onebox.options)
+      @url = url
+      @options = options
+      @status = -1
+    end
+
+    def ok?
+      status > 199 && status < 300
+    end
+
+    def status
+      check if @status == -1
+      @status
+    end
+
+    def human_status
+      case status
+      when 0
+        :connection_error
+      when 200..299
+        :success
+      when 400..499
+        :client_error
+      when 500..599
+        :server_error
+      else
+        :unknown_error
+      end
+    end
+
+    private
+
+    def check
+      res = open(@url, read_timeout: (@options.timeout || Onebox.options.timeout))
+      @status = res.status.first.to_i
+    rescue OpenURI::HTTPError => e
+      @status = e.io.status.first.to_i
+    rescue Timeout::Error, Errno::ECONNREFUSED, Net::HTTPError
+      @status = 0
+    end
+  end
+end

--- a/spec/lib/onebox/status_check_spec.rb
+++ b/spec/lib/onebox/status_check_spec.rb
@@ -1,0 +1,68 @@
+require "spec_helper"
+
+describe Onebox::StatusCheck do
+  before do
+    FakeWeb.register_uri(:get, "http://www.amazon.com/200-url", status: 200)
+    FakeWeb.register_uri(:get, "http://www.amazon.com/201-url", status: 201)
+    FakeWeb.register_uri(:get, "http://www.amazon.com/401-url", status: 401)
+    FakeWeb.register_uri(:get, "http://www.amazon.com/403-url", status: 403)
+    FakeWeb.register_uri(:get, "http://www.amazon.com/404-url", status: 404)
+    FakeWeb.register_uri(:get, "http://www.amazon.com/500-url", status: 500)
+    FakeWeb.register_uri(:get, "http://www.amazon.com/503-url", status: 503)
+    FakeWeb.register_uri(:get, "http://www.amazon.com/timeout-url", exception: Timeout::Error)
+    FakeWeb.register_uri(:get, "http://www.amazon.com/http-error", exception: Net::HTTPError)
+    FakeWeb.register_uri(:get, "http://www.amazon.com/error-connecting", exception: Errno::ECONNREFUSED)
+  end
+
+  describe '#human_status' do
+    it 'returns :success on HTTP status code 200' do
+      expect(described_class.new("http://www.amazon.com/200-url").human_status).to eq(:success)
+    end
+
+    it 'returns :success on HTTP status code 201' do
+      expect(described_class.new("http://www.amazon.com/201-url").human_status).to eq(:success)
+    end
+
+    it 'returns :client_error on HTTP status code 401' do
+      expect(described_class.new("http://www.amazon.com/401-url").human_status).to eq(:client_error)
+    end
+
+    it 'returns :client_error on HTTP status code 403' do
+      expect(described_class.new("http://www.amazon.com/403-url").human_status).to eq(:client_error)
+    end
+
+    it 'returns :client_error on HTTP status code 404' do
+      expect(described_class.new("http://www.amazon.com/404-url").human_status).to eq(:client_error)
+    end
+
+    it 'returns :server_error on HTTP status code 500' do
+      expect(described_class.new("http://www.amazon.com/500-url").human_status).to eq(:server_error)
+    end
+
+    it 'returns :server_error on HTTP status code 503' do
+      expect(described_class.new("http://www.amazon.com/503-url").human_status).to eq(:server_error)
+    end
+
+    it 'returns :connection_error if there is a connection refused error' do
+      expect(described_class.new("http://www.amazon.com/error-connecting").human_status).to eq(:connection_error)
+    end
+
+    it 'returns :connection_error if there is a timeout error' do
+      expect(described_class.new("http://www.amazon.com/timeout-url").human_status).to eq(:connection_error)
+    end
+
+    it 'returns :connection_error if there is a general HTTP error' do
+      expect(described_class.new("http://www.amazon.com/http-error").human_status).to eq(:connection_error)
+    end
+  end
+
+  describe '#ok?' do
+    it 'returns true for HTTP status codes 200-299' do
+      expect(described_class.new("http://www.amazon.com/200-url").ok?).to be true
+    end
+
+    it 'returns false for any status codes other than 200-299' do
+      expect(described_class.new("http://www.amazon.com/404-url").ok?).to be false
+    end
+  end
+end


### PR DESCRIPTION
It returns a `Onebox::StatusCheck` instance that exposes the methods
`human_status` and `ok?`, wherein `human_status` returns symbols like
`:success` and `ok?` returns true if and only if the HTTP status code
lies between 200 and 299.

The status symbols follow the broad Rails terminology for status ranges (see <http://teamco-anthill.blogspot.co.uk/2010/04/rails-http-status-code-to-symbol.html>), so that would be:

- `:success` for 200-299
- `:client_error` for 400-499
- `:server_error` for 500-599
- `:unknown_error` for all other HTTP status codes
- `:connection_error` on timeouts, socket issues, etc

