### PR TITLE
Add "always https" declarations

### DIFF
--- a/lib/onebox/engine.rb
+++ b/lib/onebox/engine.rb
@@ -38,7 +38,7 @@ module Onebox
 
       @url = link
       @uri = URI(link)
-      if self.class.always_https?
+      if always_https?
         @uri.scheme = 'https'
         @url = @uri.to_s
       end
@@ -93,6 +93,10 @@ module Onebox
         '<' => '&lt;',
         '>' => '&gt;',
       })
+    end
+
+    def always_https?
+      self.class.always_https?
     end
 
     module ClassMethods

--- a/lib/onebox/engine.rb
+++ b/lib/onebox/engine.rb
@@ -86,7 +86,7 @@ module Onebox
     end
 
     def link
-      @url.gsub(/['\"<>]/, {
+      @url.gsub(/['\"&<>]/, {
         "'" => '&#39;',
         '&' => '&amp;',
         '"' => '&quot;',

--- a/lib/onebox/engine.rb
+++ b/lib/onebox/engine.rb
@@ -10,7 +10,7 @@ module Onebox
       end.map(&method(:const_get))
     end
 
-    attr_reader :url
+    attr_reader :url, :uri
     attr_reader :cache
     attr_reader :timeout
 
@@ -37,6 +37,11 @@ module Onebox
       self.options = Onebox.options[class_name] || {} #Set the engine options extracted from global options.
 
       @url = link
+      @uri = URI(link)
+      if self.class.always_https?
+        @uri.scheme = 'https'
+        @url = @uri.to_s
+      end
       @cache = cache || Onebox.options.cache
       @timeout = timeout || Onebox.options.timeout
     end
@@ -112,6 +117,13 @@ module Onebox
         name.split("::").last.downcase.gsub(/onebox/, "")
       end
 
+      def always_https
+        @https = true
+      end
+
+      def always_https?
+        @https
+      end
     end
   end
 end

--- a/lib/onebox/engine/amazon_onebox.rb
+++ b/lib/onebox/engine/amazon_onebox.rb
@@ -6,7 +6,7 @@ module Onebox
       include HTML
 
 
-      matches_regexp(/^http:\/\/(?:www)\.amazon\.(?<tld>com|ca|de|it|es|fr|co\.jp|co\.uk|cn|in|com\.br)\//)
+      matches_regexp(/^https?:\/\/(?:www)\.amazon\.(?<tld>com|ca|de|it|es|fr|co\.jp|co\.uk|cn|in|com\.br)\//)
 
       def url
         return "http://www.amazon.#{tld}/gp/aw/d/" + URI::encode(match[:id]) if match && match[:id]

--- a/lib/onebox/engine/audio_onebox.rb
+++ b/lib/onebox/engine/audio_onebox.rb
@@ -5,6 +5,10 @@ module Onebox
 
       matches_regexp /^(https?:)?\/\/.*\.(mp3|ogg|wav)(\?.*)?$/
 
+      def always_https?
+        WhitelistedGenericOnebox.host_matches(uri, WhitelistedGenericOnebox.https_hosts)
+      end
+
       def to_html
         "<audio controls><source src='#{@url}'><a href='#{@url}'>#{@url}</a></audio>"
       end

--- a/lib/onebox/engine/github_blob_onebox.rb
+++ b/lib/onebox/engine/github_blob_onebox.rb
@@ -18,7 +18,7 @@ module Onebox
       }
 
       matches_regexp(/^https?:\/\/(www\.)?github\.com.*\/blob\//)
-
+      always_https
 
 
       def initialize(link, cache = nil, timeout = nil)

--- a/lib/onebox/engine/github_commit_onebox.rb
+++ b/lib/onebox/engine/github_commit_onebox.rb
@@ -27,8 +27,9 @@ module Onebox
           result['message'] = result['commit']['message'].split("\n", 2).last.strip
         end
 
+        ulink = URI(link)
         result['commit_date'] = Time.parse(result['commit']['author']['date']).strftime("%I:%M%p - %d %b %y")
-        result['repository_path'] = "#{URI(link).host}/#{URI(link).path.split('/')[1]}/#{URI(link).path.split('/')[2]}"
+        result['repository_path'] = "#{ulink.host}/#{ulink.path.split('/')[1]}/#{ulink.path.split('/')[2]}"
         result['repository_url'] = "https://#{result['repository_path']}"
         result
       end

--- a/lib/onebox/engine/github_commit_onebox.rb
+++ b/lib/onebox/engine/github_commit_onebox.rb
@@ -5,7 +5,8 @@ module Onebox
       include LayoutSupport
       include JSON
 
-      matches_regexp Regexp.new("^http(?:s)?://(?:www\.)?(?:(?:\w)+\.)?(github)\.com(?:/)?(?:.)*/commit/")
+      matches_regexp Regexp.new("^https?://(?:www\.)?(?:(?:\w)+\.)?(github)\.com(?:/)?(?:.)*/commit/")
+      always_https
 
       def url
         "https://api.github.com/repos/#{match[:owner]}/#{match[:repository]}/commits/#{match[:sha]}"

--- a/lib/onebox/engine/github_gist_onebox.rb
+++ b/lib/onebox/engine/github_gist_onebox.rb
@@ -8,6 +8,7 @@ module Onebox
       MAX_FILES = 3
 
       matches_regexp Regexp.new("^http(?:s)?://gist\\.(?:(?:\\w)+\\.)?(github)\\.com(?:/)?")
+      always_https
 
       def url
         "https://api.github.com/gists/#{match[:sha]}"

--- a/lib/onebox/engine/github_issue_onebox.rb
+++ b/lib/onebox/engine/github_issue_onebox.rb
@@ -5,7 +5,8 @@ module Onebox
       include Engine
       include LayoutSupport
       include JSON
-      matches_regexp Regexp.new("^http(?:s)?:\/\/(?:www\.)?(?:(?:\w)+\.)?github\.com\/(?<org>.+)\/(?<repo>.+)\/issues\/([[:digit:]]+)")
+      matches_regexp Regexp.new("^https?:\/\/(?:www\.)?(?:(?:\w)+\.)?github\.com\/(?<org>.+)\/(?<repo>.+)\/issues\/([[:digit:]]+)")
+      always_https
 
       def url
         m = match

--- a/lib/onebox/engine/github_issue_onebox.rb
+++ b/lib/onebox/engine/github_issue_onebox.rb
@@ -30,6 +30,7 @@ module Onebox
         short_content =  content_words[0..max_words].join(" ")
         short_content << "..." if content_words.length > max_words
 
+        ulink = URI(link)
         status_color = {"open"=>"#6cc644","closed"=>"#bd2c00","merged"=>"#6e5494"}
         result = { link: @url,
                    title: "Issue: " + @raw["title"],
@@ -40,8 +41,8 @@ module Onebox
                    closed_at: (@raw['closed_at'].nil? ? "" : @raw['closed_at'].split("T")[0]),
                    closed_by: @raw['closed_by'],
                    avatar: "https://avatars1.githubusercontent.com/u/#{@raw['user']['id']}?v=2&s=96",
-                   repository_path: "#{URI(link).host}/#{URI(link).path.split('/')[1]}/#{URI(link).path.split('/')[2]}",
-                   repository_url: "https://#{URI(link).host}/#{URI(link).path.split('/')[1]}/#{URI(link).path.split('/')[2]}",
+                   repository_path: "#{ulink.host}/#{ulink.path.split('/')[1]}/#{ulink.path.split('/')[2]}",
+                   repository_url: "https://#{ulink.host}/#{ulink.path.split('/')[1]}/#{ulink.path.split('/')[2]}",
                   }
       end
     end

--- a/lib/onebox/engine/github_pullrequest_onebox.rb
+++ b/lib/onebox/engine/github_pullrequest_onebox.rb
@@ -5,7 +5,8 @@ module Onebox
       include LayoutSupport
       include JSON
 
-      matches_regexp Regexp.new("^http(?:s)?://(?:www\\.)?(?:(?:\\w)+\\.)?(github)\\.com(?:/)?(?:.)*/pull/")
+      matches_regexp Regexp.new("^https?://(?:www\\.)?(?:(?:\\w)+\\.)?(github)\\.com(?:/)?(?:.)*/pull/")
+      always_https
 
       def url
         "https://api.github.com/repos/#{match[:owner]}/#{match[:repository]}/pulls/#{match[:number]}"

--- a/lib/onebox/engine/github_pullrequest_onebox.rb
+++ b/lib/onebox/engine/github_pullrequest_onebox.rb
@@ -22,7 +22,8 @@ module Onebox
         result = raw.clone
         result['link'] = link
         result['created_at'] = Time.parse(result['created_at']).strftime("%I:%M%p - %d %b %y")
-        result['repository_path'] = "#{URI(link).host}/#{URI(link).path.split('/')[1]}/#{URI(link).path.split('/')[2]}"
+        ulink = URI(link)
+        result['repository_path'] = "#{ulink.host}/#{ulink.path.split('/')[1]}/#{ulink.path.split('/')[2]}"
         result['repository_url'] = "https://#{result['repository_path']}"
         result
       end

--- a/lib/onebox/engine/google_calendar_onebox.rb
+++ b/lib/onebox/engine/google_calendar_onebox.rb
@@ -4,6 +4,7 @@ module Onebox
       include Engine
 
       matches_regexp /^(https?:)?\/\/(www\.google\.[\w.]{2,}|goo\.gl)\/calendar\/.+$/
+      always_https
 
       def to_html
         url = @url.split('&').first

--- a/lib/onebox/engine/google_docs_onebox.rb
+++ b/lib/onebox/engine/google_docs_onebox.rb
@@ -8,6 +8,7 @@ module Onebox
       end
 
       matches_regexp /^(https?:)?\/\/(docs\.google\.com)\/(?<endpoint>(#{supported_endpoints.join('|')}))\/d\/((?<key>[\w-]*)).+$/
+      always_https
 
       def to_html
         if document?

--- a/lib/onebox/engine/google_maps_onebox.rb
+++ b/lib/onebox/engine/google_maps_onebox.rb
@@ -19,6 +19,8 @@ module Onebox
         end
       end
 
+      always_https
+
       # Matches shortened Google Maps URLs
       matches_regexp :short,      %r"^(https?:)?//goo\.gl/maps/"
 
@@ -95,7 +97,7 @@ module Onebox
           url += "&q=#{$1}" if match = @url.match(/\/place\/([^\/\?]+)/)
           url += "&cid=#{($1 + $2).to_i(16)}" if @url.match(/!3m1!1s0x(\h{16}):0x(\h{16})/)
           @url = url
-          @placeholder = "http://maps.googleapis.com/maps/api/staticmap?maptype=roadmap&center=#{location}&zoom=#{zoom}&size=690x400&sensor=false"
+          @placeholder = "https://maps.googleapis.com/maps/api/staticmap?maptype=roadmap&center=#{location}&zoom=#{zoom}&size=690x400&sensor=false"
 
         when :custom
           url = @url.dup
@@ -113,7 +115,7 @@ module Onebox
           fov = (match[:zoom].to_f / 100.0).round(4).to_s
           zoom = match[:zoom].to_f.round
           @url = "https://www.google.com/maps/embed?pb=!3m2!2sen!4v0!6m8!1m7!1s#{panoid}!2m2!1d#{lon}!2d#{lat}!3f#{heading}!4f#{pitch}!5f#{fov}"
-          @placeholder = "http://maps.googleapis.com/maps/api/streetview?size=690x400&location=#{lon},#{lat}&pano=#{panoid}&fov=#{zoom}&heading=#{heading}&pitch=#{pitch}&sensor=false"
+          @placeholder = "https://maps.googleapis.com/maps/api/streetview?size=690x400&location=#{lon},#{lat}&pano=#{panoid}&fov=#{zoom}&heading=#{heading}&pitch=#{pitch}&sensor=false"
 
         when :canonical
           uri = URI(@url)
@@ -136,7 +138,7 @@ module Onebox
             zoom = query["z"]
           end
           @url = @url.sub('output=classic', 'output=embed')
-          @placeholder = "http://maps.googleapis.com/maps/api/staticmap?maptype=roadmap&size=690x400&sensor=false&center=#{location}&zoom=#{zoom}"
+          @placeholder = "https://maps.googleapis.com/maps/api/staticmap?maptype=roadmap&size=690x400&sensor=false&center=#{location}&zoom=#{zoom}"
 
         else
           raise "unexpected url type #{type.inspect}"

--- a/lib/onebox/engine/google_play_app_onebox.rb
+++ b/lib/onebox/engine/google_play_app_onebox.rb
@@ -10,7 +10,8 @@ module Onebox
       }
 
 
-      matches_regexp Regexp.new("^http(?:s)?://play\\.(?:(?:\\w)+\\.)?(google)\\.com(?:/)?/store/apps/")
+      matches_regexp Regexp.new("^https?://play\\.(?:(?:\\w)+\\.)?(google)\\.com(?:/)?/store/apps/")
+      always_https
 
       private
 

--- a/lib/onebox/engine/image_onebox.rb
+++ b/lib/onebox/engine/image_onebox.rb
@@ -5,6 +5,10 @@ module Onebox
 
       matches_regexp /^(https?:)?\/\/.+\.(png|jpg|jpeg|gif|bmp|tif|tiff)(\?.*)?$/i
 
+      def always_https?
+        WhitelistedGenericOnebox.host_matches(uri, WhitelistedGenericOnebox.https_hosts)
+      end
+
       def to_html
         # Fix Dropbox image links
         if /^https:\/\/www.dropbox.com\/s\//.match @url

--- a/lib/onebox/engine/pubmed_onebox.rb
+++ b/lib/onebox/engine/pubmed_onebox.rb
@@ -4,7 +4,7 @@ module Onebox
       include Engine
       include LayoutSupport
 
-      matches_regexp Regexp.new("^http(?:s)?://(?:(?:\\w)+\\.)?(www.ncbi.nlm.nih)\\.gov(?:/)?/pubmed/")
+      matches_regexp Regexp.new("^https?://(?:(?:\\w)+\\.)?(www.ncbi.nlm.nih)\\.gov(?:/)?/pubmed/")
 
       private
 

--- a/lib/onebox/engine/soundcloud_onebox.rb
+++ b/lib/onebox/engine/soundcloud_onebox.rb
@@ -5,6 +5,7 @@ module Onebox
       include StandardEmbed
 
       matches_regexp(/^https?:\/\/.*soundcloud\.com/)
+      always_https
 
       def to_html
         get_oembed_data[:html].gsub!('height="400"', 'height="250"')
@@ -17,7 +18,7 @@ module Onebox
       private
 
       def get_oembed_data
-        Onebox::Helpers.symbolize_keys(::MultiJson.load(Onebox::Helpers.fetch_response("http://soundcloud.com/oembed.json?url=#{url}").body))
+        Onebox::Helpers.symbolize_keys(::MultiJson.load(Onebox::Helpers.fetch_response("https://soundcloud.com/oembed.json?url=#{url}").body))
       end
     end
   end

--- a/lib/onebox/engine/stack_exchange_onebox.rb
+++ b/lib/onebox/engine/stack_exchange_onebox.rb
@@ -9,7 +9,7 @@ module Onebox
         %w(stackexchange stackoverflow superuser serverfault askubuntu)
       end
 
-      matches_regexp /^http:\/\/(?:(?:(?<subsubdomain>\w*)\.)?(?<subdomain>\w*)\.)?(?<domain>#{domains.join('|')})\.com\/(?:questions|q)\/(?<question>\d*)/
+      matches_regexp /^https?:\/\/(?:(?:(?<subsubdomain>\w*)\.)?(?<subdomain>\w*)\.)?(?<domain>#{domains.join('|')})\.com\/(?:questions|q)\/(?<question>\d*)/
 
       private
 
@@ -19,7 +19,7 @@ module Onebox
 
       def url
         domain = URI(@url).host
-        "http://api.stackexchange.com/2.1/questions/#{match[:question]}?site=#{domain}"
+        "https://api.stackexchange.com/2.1/questions/#{match[:question]}?site=#{domain}"
       end
 
       def data

--- a/lib/onebox/engine/stack_exchange_onebox.rb
+++ b/lib/onebox/engine/stack_exchange_onebox.rb
@@ -11,6 +11,10 @@ module Onebox
 
       matches_regexp /^https?:\/\/(?:(?:(?<subsubdomain>\w*)\.)?(?<subdomain>\w*)\.)?(?<domain>#{domains.join('|')})\.com\/(?:questions|q)\/(?<question>\d*)/
 
+      def always_https?
+        uri.host.split('.').length <= 3
+      end
+
       private
 
       def match

--- a/lib/onebox/engine/standard_embed.rb
+++ b/lib/onebox/engine/standard_embed.rb
@@ -28,6 +28,10 @@ module Onebox
       # Sites that work better with OpenGraph
       add_opengraph_provider /gfycat\.com\//
 
+      def always_https?
+        WhitelistedGenericOnebox.host_matches(uri, WhitelistedGenericOnebox.https_hosts)
+      end
+
       def raw
         return @raw if @raw
 

--- a/lib/onebox/engine/twitter_status_onebox.rb
+++ b/lib/onebox/engine/twitter_status_onebox.rb
@@ -5,7 +5,8 @@ module Onebox
       include LayoutSupport
       include HTML
 
-      matches_regexp Regexp.new("^http(?:s)?://(?:www\\.)?(?:(?:\\w)+\\.)?(twitter)\\.com(?:/)?(?:.)*/status(es)?/")
+      matches_regexp Regexp.new("^https?://(?:www\\.)?(?:(?:\\w)+\\.)?(twitter)\\.com(?:/)?(?:.)*/status(es)?/")
+      always_https
 
       private
 

--- a/lib/onebox/engine/video_onebox.rb
+++ b/lib/onebox/engine/video_onebox.rb
@@ -5,6 +5,10 @@ module Onebox
 
       matches_regexp /^(https?:)?\/\/.*\.(mov|mp4|webm|ogv)(\?.*)?$/
 
+      def always_https?
+        WhitelistedGenericOnebox.host_matches(uri, WhitelistedGenericOnebox.https_hosts)
+      end
+
       def to_html
         "<video width='100%' height='100%' controls><source src='#{@url}'><a href='#{@url}'>#{@url}</a></video>"
       end

--- a/lib/onebox/engine/whitelisted_generic_onebox.rb
+++ b/lib/onebox/engine/whitelisted_generic_onebox.rb
@@ -142,17 +142,16 @@ module Onebox
         @html_providers = new_provs
       end
 
-      # A re-written URL coverts https:// -> // - it is useful on HTTPS sites that embed
-      # youtube for example
+      # A re-written URL coverts http:// -> https://
       def self.rewrites
-        @rewrites ||= default_rewrites.dup
+        @rewrites ||= https_hosts.dup
       end
 
       def self.rewrites=(new_list)
         @rewrites = new_list
       end
 
-      def self.default_rewrites
+      def self.https_hosts
         %w(slideshare.net imgur.com dailymotion.com livestream.com)
       end
 
@@ -187,11 +186,11 @@ module Onebox
         data[:type] == "article"
       end
 
-      def rewrite_agnostic(html)
+      def rewrite_https(html)
         return html unless html
         uri = URI(@url)
         if WhitelistedGenericOnebox.host_matches(uri, WhitelistedGenericOnebox.rewrites)
-          html.gsub!(/https?:\/\//, '//')
+          html.gsub!(/http:\/\//, 'https://')
         end
         html
       end
@@ -217,7 +216,7 @@ module Onebox
       end
 
       def to_html
-        rewrite_agnostic(generic_html)
+        rewrite_https(generic_html)
       end
 
       def placeholder_html

--- a/lib/onebox/engine/wikipedia_onebox.rb
+++ b/lib/onebox/engine/wikipedia_onebox.rb
@@ -6,6 +6,7 @@ module Onebox
       include HTML
 
       matches_regexp(/^https?:\/\/.*wikipedia\.(com|org)/)
+      always_https
 
       private
 

--- a/lib/onebox/engine/youtube_onebox.rb
+++ b/lib/onebox/engine/youtube_onebox.rb
@@ -5,6 +5,7 @@ module Onebox
       include StandardEmbed
 
       matches_regexp(/^https?:\/\/(?:www\.)?(?:m\.)?(?:youtube\.com|youtu\.be)\/.+$/)
+      always_https
 
       # Try to get the video ID. Works for URLs of the form:
       # * https://www.youtube.com/watch?v=Z0UISCEe52Y
@@ -58,7 +59,7 @@ module Onebox
       end
 
       def video_title
-        yt_oembed_url = "http://www.youtube.com/oembed?format=json&url=http://www.youtube.com/watch?v=#{video_id.split('?')[0]}"
+        yt_oembed_url = "https://www.youtube.com/oembed?format=json&url=https://www.youtube.com/watch?v=#{video_id.split('?')[0]}"
         yt_oembed_data = Onebox::Helpers.symbolize_keys(::MultiJson.load(Onebox::Helpers.fetch_response(yt_oembed_url).body))
         yt_oembed_data[:title]
       rescue
@@ -112,11 +113,6 @@ module Onebox
         else
           nil
         end
-      end
-
-      # Note: May throw! Make sure to recue.
-      def uri
-        @_uri ||= URI(@url)
       end
 
       def params

--- a/spec/lib/onebox/engine/stack_exchange_onebox_spec.rb
+++ b/spec/lib/onebox/engine/stack_exchange_onebox_spec.rb
@@ -3,7 +3,7 @@ require "spec_helper"
 describe Onebox::Engine::StackExchangeOnebox do
   before(:all) do
     @link = "http://stackoverflow.com/questions/17992553/concept-behind-these-four-lines-of-tricky-c-code"
-    fake("http://api.stackexchange.com/2.1/questions/17992553?site=stackoverflow.com", response(described_class.onebox_name))
+    fake("https://api.stackexchange.com/2.1/questions/17992553?site=stackoverflow.com", response(described_class.onebox_name))
   end
 
   include_context "engines"

--- a/spec/lib/onebox/engine/whitelisted_generic_onebox_spec.rb
+++ b/spec/lib/onebox/engine/whitelisted_generic_onebox_spec.rb
@@ -50,18 +50,18 @@ describe Onebox::Engine::WhitelistedGenericOnebox do
   describe 'rewrites' do
     class DummyOnebox < Onebox::Engine::WhitelistedGenericOnebox
       def generic_html
-        "<iframe src='https://youtube.com/asdf'></iframe>"
+        "<iframe src='http://youtube.com/asdf'></iframe>"
       end
     end
 
     it "doesn't rewrite URLs that arent in the list" do
       Onebox::Engine::WhitelistedGenericOnebox.rewrites = []
-      expect(DummyOnebox.new("http://youtube.com").to_html).to eq "<iframe src='https://youtube.com/asdf'></iframe>"
+      expect(DummyOnebox.new("http://youtube.com").to_html).to eq "<iframe src='http://youtube.com/asdf'></iframe>"
     end
 
     it "rewrites URLs when whitelisted" do
       Onebox::Engine::WhitelistedGenericOnebox.rewrites = %w(youtube.com)
-      expect(DummyOnebox.new("http://youtube.com").to_html).to eq "<iframe src='//youtube.com/asdf'></iframe>"
+      expect(DummyOnebox.new("http://youtube.com").to_html).to eq "<iframe src='https://youtube.com/asdf'></iframe>"
     end
   end
 

--- a/spec/lib/onebox/engine/wikipedia_onebox_spec.rb
+++ b/spec/lib/onebox/engine/wikipedia_onebox_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 describe Onebox::Engine::WikipediaOnebox do
   before(:all) do
     @link = "http://en.wikipedia.org/wiki/Billy_Jack"
+    fake("https://en.wikipedia.org/wiki/Billy_Jack", response(described_class.onebox_name))
   end
 
   include_context "engines"

--- a/spec/lib/onebox/engine/youtube_onebox_spec.rb
+++ b/spec/lib/onebox/engine/youtube_onebox_spec.rb
@@ -2,8 +2,9 @@ require 'spec_helper'
 
 describe Onebox::Engine::YoutubeOnebox do
   before do
-    fake("http://www.youtube.com/watch?feature=player_embedded&v=21Lk4YiASMo", response("youtube"))
+    fake("https://www.youtube.com/watch?feature=player_embedded&v=21Lk4YiASMo", response("youtube"))
     fake("https://www.youtube.com/channel/UCL8ZULXASCc1I_oaOT0NaOQ", response("youtube-channel"))
+    fake("https://www.youtube.com/playlist?list=PL5308B2E5749D1696", response("youtube-playlist"))
   end
 
   it "adds wmode=opaque" do
@@ -31,7 +32,8 @@ describe Onebox::Engine::YoutubeOnebox do
   it "can onebox a playlist" do
     pending('no opengraph on playlists, needs special handling')
 
-    Onebox.preview('https://www.youtube.com/playlist?list=PL5308B2E5749D1696').to_s
+    expect(Onebox.preview('https://www.youtube.com/playlist?list=PL5308B2E5749D1696')
+    .to_s).to match(/Dear Sophie/)
   end
 
   it "does not make HTTP requests unless necessary" do


### PR DESCRIPTION
This fixes mixed-content warnings for i.imgur.com and YouTube thumbnails, and makes sure that all requests leaving the server for these websites are always https.

https://meta.discourse.org/t/storing-images-in-the-cloud/6779/5

Also fixes that & was not being escaped in `link`