### PR TITLE
Updated google calendar url regex to match calendar.google.com

### DIFF
--- a/lib/onebox/engine/google_calendar_onebox.rb
+++ b/lib/onebox/engine/google_calendar_onebox.rb
@@ -3,7 +3,7 @@ module Onebox
     class GoogleCalendarOnebox
       include Engine
 
-      matches_regexp /^(https?:)?\/\/(www\.google\.[\w.]{2,}|goo\.gl)\/calendar\/.+$/
+      matches_regexp /^(https?:)?\/\/((www|calendar)\.google\.[\w.]{2,}|goo\.gl)\/calendar\/.+$/
       always_https
 
       def to_html


### PR DESCRIPTION
Google now seems to be using calendar.google.com (at least in some cases) when they generate embed links for calendars.  This change allows either www.google.com (which was already being matched), or calendar.google.com as the host.