### PR TITLE
Fix new engine instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Adding Support for a new URL
   5. Create new fixture from HTML response for your FakeWeb request(s)
 
      ``` bash
-     curl --output spec/fixtures/oneboxname.response -L -X -GET http://example.com
+     curl --output spec/fixtures/oneboxname.response -L -X GET http://example.com
      ```
 
   6. Require in Engine module

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Adding Support for a new URL
        let(:html) { described_class.new(link).to_html }
 
        before do
-         fake(link, response("name.response"))
+         fake(link, response("name"))
        end
 
        it "has the video's title" do


### PR DESCRIPTION
I'm reviewing the new engine instructions in the README since I hit some roadblocks just copying and pasting code from it. I think this changes will make life easier for future contributors.
# First problem (curl typo):

I was trying to follow the new engine instructions and hit a bump at the curl fixture capture. The original version doesn't work on my machine (because it emits a `-GET` method and the server responds with `501 Method Not Supported`). I had to remove this dash to make it work.

Here is the version of curl I'm using: 

```
$ curl -V
curl 7.27.0 (i686-pc-linux-gnu) libcurl/7.27.0 OpenSSL/1.0.1c zlib/1.2.7 libidn/1.25 librtmp/2.3
Protocols: dict file ftp ftps gopher http https imap imaps ldap ldaps pop3 pop3s rtmp rtsp smtp smtps telnet tftp 
Features: Debug GSS-Negotiate IDN IPv6 Largefile NTLM NTLM_WB SSL libz TLS-SRP
```
# Second problem (duplicated .response suffix):

My tests were failing because the README told me to call `fake(link, response("name.response"))`, but `response` adds its own suffix to the file name before trying to find the canned response.
