### PR TITLE
search for 'url', not 'image', if oembed is of 'photo' type

### DIFF
--- a/lib/onebox/engine/whitelisted_generic_onebox.rb
+++ b/lib/onebox/engine/whitelisted_generic_onebox.rb
@@ -267,7 +267,7 @@ module Onebox
       def image_html
         return @image_html if @image_html
 
-        return @image_html = "<img src=\"#{data[:image]}\">" if data[:image]
+        return @image_html = "<img src=\"#{data[:url]}\">" if data[:url]
 
         if data[:thumbnail_url]
           @image_html = "<img src=\"#{data[:thumbnail_url]}\""


### PR DESCRIPTION
Please look at oembed specification http://oembed.com

> 2.3.4.1. The photo type
> 
> This type is used for representing static photos. The following parameters are defined:
> 
> url (required)
> The source URL of the image. Consumers should be able to insert this URL into an <img> element. Only HTTP and HTTPS URLs are valid.
