### PR TITLE
Fix Amazon onebox data serialization

### DIFF
--- a/lib/onebox/engine/amazon_onebox.rb
+++ b/lib/onebox/engine/amazon_onebox.rb
@@ -36,7 +36,7 @@ module Onebox
         if (main_image = raw.css("#main-image")) && main_image.any?
           attributes = main_image.first.attributes
 
-          return attributes["data-a-hires"] if attributes["data-a-hires"]
+          return attributes["data-a-hires"].to_s if attributes["data-a-hires"]
 
           if attributes["data-a-dynamic-image"]
             return ::JSON.parse(attributes["data-a-dynamic-image"].value).keys.first
@@ -44,7 +44,7 @@ module Onebox
         end
 
         if (landing_image = raw.css("#landingImage")) && landing_image.any?
-          landing_image.first["src"]
+          landing_image.first["src"].to_s
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,14 @@ require 'mocha/api'
 
 require_relative "support/html_spec_helper"
 
+# Monkey-patch fakeweb to support Ruby 2.4+.
+# See https://github.com/chrisk/fakeweb/pull/59.
+module FakeWeb
+  class StubSocket
+    def close; end
+  end
+end
+
 RSpec.configure do |config|
   config.before(:all) do
     FakeWeb.allow_net_connect = false
@@ -49,6 +57,10 @@ shared_examples_for "an engine" do
 
     it "includes link" do
       expect(data[:link]).not_to be_nil
+    end
+
+    it "is serializable" do
+      expect { Marshal.dump(data) }.to_not raise_error
     end
   end
 end


### PR DESCRIPTION
`Nokogiri::XML::Attr` cannot be serialized, so `image` must return a string for compatibility with caches that require serialization.