### PR TITLE
Allow optional trailing slash on twitter URLs, and add support for video/photo URLs

### DIFF
--- a/lib/onebox/engine/twitter_status_onebox.rb
+++ b/lib/onebox/engine/twitter_status_onebox.rb
@@ -5,7 +5,7 @@ module Onebox
       include LayoutSupport
       include HTML
 
-      matches_regexp /^https?:\/\/(mobile\.|www\.)?twitter\.com\/.+?\/status(es)?\/\d+$/
+      matches_regexp /^https?:\/\/(mobile\.|www\.)?twitter\.com\/.+?\/status(es)?\/\d+(\/(video|photo)\/\d?+)?+\/?$/
       always_https
 
       private


### PR DESCRIPTION
Video/photo links do not need to be treated differently from standard links, since all photo/video links have their "canonical URL" set to the the raw "status" URL, so all we need to do is match them to the existing onebox.