### PR TITLE
Support Mustache v1.0.4

### DIFF
--- a/lib/onebox/layout.rb
+++ b/lib/onebox/layout.rb
@@ -11,6 +11,7 @@ module Onebox
     attr_reader :view
 
     def initialize(name, record, cache)
+      super()
       @cache = cache
       @record = Onebox::Helpers.symbolize_keys(record)
 

--- a/lib/onebox/view.rb
+++ b/lib/onebox/view.rb
@@ -7,6 +7,7 @@ module Onebox
     attr_reader :record
 
     def initialize(name, record)
+      super()
       @record = record
       self.template_name = name
       self.template_path = load_paths.last


### PR DESCRIPTION
Call `super()` in classes that inherit from `Mustache`, so that the `@options` variable [gets set](https://github.com/mustache/mustache/blob/7dd0a3773e7c65351cf3d75f17e9e91919bafa33/lib/mustache.rb#L80).

Would appreciate a release as soon as this is merged!