### PR TITLE
Update for new Steam Store URLs

### DIFF
--- a/lib/onebox/engine/steam_store_onebox.rb
+++ b/lib/onebox/engine/steam_store_onebox.rb
@@ -22,7 +22,9 @@ module Onebox
       end
 
       def to_html
-        iframe_url = @url.gsub('/app/', '/widget/')
+        # FIX: Steam widgets fail on extra paths and the Steam store has started added extra paths to app names
+        widget_id = /(?<=store.steampowered.com\/app)\/\d+/.match(@url)
+        iframe_url = "https://store.steampowered.com/widget#{widget_id}"
         escaped_src = ::Onebox::Helpers.normalize_url_for_output(iframe_url)
 
         <<-HTML


### PR DESCRIPTION
The Steam Store has changed their public URLs to include a description part after the app id. Unfortunately, anything included after the /widget iframe path now fails to resolve. This change takes the app id from the URL only and puts the widget/{app_id} part on.

Examples:

Old URL from Steam store page: http://store.steampowered.com/app/10
New URL (as of 25 April 2017): http://store.steampowered.com/app/10/CounterStrike/

Broken Widget path: http://store.steampowered.com/widget/10/CounterStrike/
Fixed Widget path: http://store.steampowered.com/widget/10