### PR TITLE
Steam Store URL path update

### DIFF
--- a/lib/onebox/engine/steam_store_onebox.rb
+++ b/lib/onebox/engine/steam_store_onebox.rb
@@ -22,7 +22,7 @@ module Onebox
       end
 
       def to_html
-        iframe_url = @url.gsub('/app/', '/widget/')
+        iframe_url = @url[/https?:\/\/store\.steampowered\.com\/app\/\d+/].gsub("/app/", "/widget/")
         escaped_src = ::Onebox::Helpers.normalize_url_for_output(iframe_url)
 
         <<-HTML


### PR DESCRIPTION
The Steam Store has changed their public URLs to include a description part after the app id. Unfortunately, anything included after the /widget iframe path now fails to resolve. This change takes the app id from the URL only and puts the widget/{app_id} part on.

Examples:

Old URL from Steam store page: http://store.steampowered.com/app/10
New URL (as of 25 April 2017): http://store.steampowered.com/app/10/CounterStrike/

Broken Widget path: http://store.steampowered.com/widget/10/CounterStrike/
Fixed Widget path: http://store.steampowered.com/widget/10