### PR TITLE
FEATURE: use Sinatra::Reloader in development

### DIFF
--- a/lib/onebox/web.rb
+++ b/lib/onebox/web.rb
@@ -12,6 +12,8 @@ module Onebox
     set :public_folder, Proc.new { "#{root}/assets" }
     set :views, Proc.new { "#{root}/views" }
     configure :development do
+      register Sinatra::Reloader
+      also_reload 'lib/**/*.rb'
       enable :logging
     end
 


### PR DESCRIPTION
This commit should avoid the need to constantly reload the server in dev mode.