### PR TITLE
FIX: relative path mutation wasn’t used

### DIFF
--- a/lib/onebox/layout.rb
+++ b/lib/onebox/layout.rb
@@ -20,7 +20,7 @@ module Onebox
       end
 
       @md5 = Digest::MD5.new
-      @view = View.new(name, record)
+      @view = View.new(name, @record)
       @template_name = "_layout"
       @template_path = load_paths.last
     end

--- a/spec/lib/onebox/layout_spec.rb
+++ b/spec/lib/onebox/layout_spec.rb
@@ -69,5 +69,11 @@ describe Onebox::Layout do
       html = described_class.new("amazon", record, cache).to_html
       expect(html).to include(%|"foo"|)
     end
+
+    it "rewrites relative image path" do
+      record = { image: "/image.png", link: "https://discourse.org" }
+      klass = described_class.new("whitelistedgeneric", record, cache)
+      expect(klass.view.record[:image]).to include("https://discourse.org")
+    end
   end
 end


### PR DESCRIPTION
We also might want to do

```ruby
@record[:image] =
"#{uri.scheme}://#{uri.host}/#{@record[:image][/(?!\/).*/]}"
```

To avoid getting
`https://us.battle.net//forums/static/images/social-thumbs/overwatch.png
` instead of
`https://us.battle.net/forums/static/images/social-thumbs/overwatch.png`
 (watch for the double /)

It will work with `//` so I'm not fixing it for now.