### PR TITLE
fix calling inner_text on nil if

### DIFF
--- a/lib/onebox/engine/amazon_onebox.rb
+++ b/lib/onebox/engine/amazon_onebox.rb
@@ -73,7 +73,7 @@ module Onebox
           end
 
         summary = raw.at("#productDescription")
-        result[:description] = og[:description] || summary.inner_text
+        result[:description] = og[:description] || summary&.inner_text
         result
       end
     end


### PR DESCRIPTION
Problem. 

```
[1] pry(main)> require 'onebox'
=> true
[2] pry(main)> a = Onebox.preview("https://www.amazon.com/Amazon-com-Amount-Black-Classic-Design/dp/B01K8RMDO0").to_s
NoMethodError: undefined method `inner_text' for nil:NilClass
from /home/ziya/.rvm/gems/ruby-2.3.1/gems/onebox-1.8.22/lib/onebox/engine/amazon_onebox.rb:76:in `data'
```

A quick solution - adding safe navigation operator (`&`) to `summary`.

```
[1] pry(main)> require 'onebox'
=> true
[2] pry(main)> class Onebox::Engine::AmazonOnebox
[2] pry(main)*   def data
...
[2] pry(main)*     result[:description] = og[:description] || summary&.inner_text    
[2] pry(main)*     result    
[2] pry(main)*   end  
[2] pry(main)* end  
=> :data
[3] pry(main)> a = Onebox.preview("https://www.amazon.com/Amazon-com-Amount-Black-Classic-Design/dp/B01K8RMDO0").to_s
=> "<aside class=\"onebox amazon\">\n  <header class=\"source\">\n    <a href=\"https://www.amazon.com/Amazon-com-Amount-Black-Classic-Design/dp/B01K8RMDO0\" target=\"_blank\" rel=\"nofollow noopener\">amazon.com</a>\n  </header>\n  <article class=\"onebox-body\">\n    <img src=\"https://images-na.ssl-images-amazon.com/images/I/51RQ4Xg5nKL._AC_SY400_.jpg\" class=\"thumbnail\">\n\n<h3><a href=\"https://www.amazon.com/Amazon-com-Amount-Black-Classic-Design/dp/B01K8RMDO0\" target=\"_blank\" rel=\"nofollow noopener\">Amazon.com Gift Card for Any Amount in a Black Gift Box (Classic Black Card Design)</a></h3>\n\n<p></p>\n<p><strong>$50.00\n</strong></p>\n\n  </article>\n  <div class=\"onebox-metadata\">\n    \n    \n  </div>\n  <div style=\"clear: both\"></div>\n</aside>\n"
```


This also can be applied to other calls, because, the thing you are looking for, might not be in same selector after a time.