### PR TITLE
Fixes sketchfab embeds

### DIFF
--- a/lib/onebox/engine/sketchfab_onebox.rb
+++ b/lib/onebox/engine/sketchfab_onebox.rb
@@ -10,7 +10,7 @@ module Onebox
       def to_html
         opengraph = get_opengraph
 
-        src = opengraph[:video_url].gsub("?autostart=1", "")
+        src = opengraph[:video_url].gsub("autostart=1", "")
         escaped_src = ::Onebox::Helpers.normalize_url_for_output(src)
 
         <<-HTML


### PR DESCRIPTION
Recent changes to the og:video tag on sketchfab allows us to pass several url parameters instead of just autostart.
For links that whose first parameter is not autostart, the previous code did nothing, causing the embed to autostart.
For links that have several parameters and start with autostart, the `?` is removed from the url, causing a 404.

This change removes only `autostart=1`, removing the autostart behavior and keeping all other behaviors as expected.