### PR TITLE
New onebox for gfycat

### DIFF
--- a/lib/onebox/engine/gfycat_onebox.rb
+++ b/lib/onebox/engine/gfycat_onebox.rb
@@ -18,14 +18,32 @@ module Onebox
 
       def to_html
         <<-HTML
-          <div>
-            <video controls loop autoplay muted poster="#{data[:posterUrl]}" width="#{data[:width]}" height="#{data[:height]}">
-              <source id="webmSource" src="#{data[:webmUrl]}" type="video/webm">
-              <source id="mp4Source" src="#{data[:mp4Url]}" type="video/mp4">
-              <img title="Sorry, your browser doesn't support HTML5 video." src="#{data[:posterUrl]}">
-            </video><br/>
-            <a href="#{data[:url]}">#{data[:name]}</a>
-          </div>
+          <aside class="onebox gfycat">
+            <header class="source">
+              <img src="https://gfycat.com/static/favicons/favicon-96x96.png" class="site-icon" width="64" height="64">
+              <a href="#{data[:url]}" target="_blank" rel="nofollow noopener">Gfycat.com</a>
+            </header>
+            <article class="onebox-body">
+              <h4>
+                #{data[:title]} by
+                <a href="https://gfycat.com/@#{data[:author]}" target="_blank" rel="nofollow noopener">
+                  <span>#{data[:author]}</span>
+                </a>
+              </h4>
+
+              <div class="video">
+                <video controls loop autoplay muted poster="#{data[:posterUrl]}" style="--aspect-ratio: #{data[:width]}/#{data[:height]}">
+                  <source id="webmSource" src="#{data[:webmUrl]}" type="video/webm">
+                  <source id="mp4Source" src="#{data[:mp4Url]}" type="video/mp4">
+                  <img title="Sorry, your browser doesn't support HTML5 video." src="#{data[:posterUrl]}">
+                </video>
+              </div>
+              <p>
+                <span class="label1">#{data[:tags]}</span>
+              </p>
+
+            </article>
+          </aside>
         HTML
       end
 
@@ -41,12 +59,19 @@ module Onebox
       private
 
         def match
-          @match ||= @url.match(/^https?:\/\/gfycat\.com\/(?<name>.+)/)
+          @match ||= @url.match(/^https?:\/\/gfycat\.com\/(gifs\/detail\/)?(?<name>.+)/)
         end
 
         def data
+
+          total_tags = [raw['gfyItem']['tags'], raw['gfyItem']['userTags']].flatten.compact
+          tag_links = total_tags&.map{|t| "<a href='https://gfycat.com/gifs/search/#{t}'>##{t}</a>"}&.join(' ')
+
           {
             name: raw['gfyItem']['gfyName'],
+            title: raw['gfyItem']['title'] || 'No Title',
+            author: raw['gfyItem']['userName'],
+            tags: tag_links,
             url: @url,
             posterUrl: raw['gfyItem']['posterUrl'],
             webmUrl: raw['gfyItem']['webmUrl'],

--- a/lib/onebox/sanitize_config.rb
+++ b/lib/onebox/sanitize_config.rb
@@ -12,7 +12,7 @@ class Sanitize
         'embed'  => %w[height src type width],
         'iframe' => %w[allowfullscreen frameborder height scrolling src width],
         'source' => %w[src type],
-        'video'  => %w[controls height loop width],
+        'video'  => %w[controls height loop width autoplay],
         'div'    => [:data], # any data-* attributes
       },
 


### PR DESCRIPTION
## OLD

### Screenshot

![image](https://user-images.githubusercontent.com/1385470/36104896-62585524-0ffa-11e8-9507-e7327401e22c.png)


## NEW

### Features
- Title
- Favicon
- Author
- Tags
- Auto-plays on desktop
- Supports details gfycat URL

### Screenshot

![image](https://user-images.githubusercontent.com/1385470/36104472-4dc39584-0ff9-11e8-9926-e6e453175260.png)


---

This will need a few lines off CSS in Discourse:

```diff
diff --git a/app/assets/stylesheets/common/base/onebox.scss b/app/assets/stylesheets/common/base/onebox.scss
index 61d92687fe..c692cfceb7 100644
--- a/app/assets/stylesheets/common/base/onebox.scss
+++ b/app/assets/stylesheets/common/base/onebox.scss
@@ -463,10 +463,22 @@ aside.onebox.stackexchange .onebox-body {
   .label2 {
     float: right;
   }
-  .site-icon {
-    width: 16px;
-    height: 16px;
-    margin-right: 3px;
+}
+
+.onebox {
+  &.whitelistedgeneric,
+  &.gfycat {
+    .site-icon {
+      width: 16px;
+      height: 16px;
+      margin-right: 3px;
+    }
+  }
+}
+
+.onebox.gfycat p {
+  span.label1 a {
+    white-space: nowrap;
   }
 }
```