### PR TITLE
catch up Ruby 2.6.

### DIFF
--- a/lib/onebox/preview.rb
+++ b/lib/onebox/preview.rb
@@ -2,7 +2,9 @@ module Onebox
   class Preview
     attr_reader :cache
 
-    WEB_EXCEPTIONS ||= [Net::HTTPServerException, OpenURI::HTTPError, Timeout::Error, Net::HTTPError, Errno::ECONNREFUSED]
+    # see https://bugs.ruby-lang.org/issues/14688
+    client_exception = defined?(Net::HTTPClientException) ? Net::HTTPClientException : Net::HTTPServerException
+    WEB_EXCEPTIONS ||= [client_exception, OpenURI::HTTPError, Timeout::Error, Net::HTTPError, Errno::ECONNREFUSED]
 
     def initialize(link, parameters = Onebox.options)
       @url = link


### PR DESCRIPTION
Ruby 2.6 deprecated Net::HTTPServerException.
see https://bugs.ruby-lang.org/issues/14688