### PR TITLE
Fix Sketchfab link regexp

### DIFF
--- a/lib/onebox/engine/sketchfab_onebox.rb
+++ b/lib/onebox/engine/sketchfab_onebox.rb
@@ -4,7 +4,7 @@ module Onebox
       include Engine
       include StandardEmbed
 
-      matches_regexp(/^https?:\/\/sketchfab\.com\/models\/[a-z0-9]{32}/)
+      matches_regexp(/^https?:\/\/sketchfab\.com\/(?:models\/|3d-models\/(?:[^\/\s]+-)?)([a-z0-9]{32})/)
       always_https
 
       def to_html


### PR DESCRIPTION
Hey,

Lately we changed our 3d model page url scheme. It used to look like this `https://sketchfab.com/models/<id>` and now it can have one of the three following shapes:
- `https://sketchfab.com/models/<id>`
- `https://sketchfab.com/3d-models/<id>`
- `https://sketchfab.com/3d-models/<slug>-<id>`

I updated your regexp with the one we use internally @Sketchfab.

Cheers!
