### PR TITLE
FIX: use vimeo engine instead of whitelisting it

### DIFF
--- a/lib/onebox/engine/whitelisted_generic_onebox.rb
+++ b/lib/onebox/engine/whitelisted_generic_onebox.rb
@@ -119,7 +119,6 @@ module Onebox
           usatoday.com
           viddler.com
           videojug.com
-          vimeo.com
           vine.co
           walmart.com
           washingtonpost.com


### PR DESCRIPTION
Currently we do not hit VimeoOnebox engine.

```ruby
Onebox.preview("https://vimeo.com/97765630").send(:engine).class
#Onebox::Engine::WhitelistedGenericOnebox
```

