### PR TITLE
Update github_blob engine to support displaying stl files

### DIFF
--- a/lib/onebox/engine/github_blob_onebox.rb
+++ b/lib/onebox/engine/github_blob_onebox.rb
@@ -15,7 +15,7 @@ module Onebox
         /github\.com\/(?<user>[^\/]+)\/(?<repo>[^\/]+)\/blob\/(?<sha1>[^\/]+)\/(?<file>[^#]+)(#(L(?<from>[^-]*)(-L(?<to>.*))?))?/mi
       end
       def raw_template(m)
-        "https://raw.github.com/#{m[:user]}/#{m[:repo]}/#{m[:sha1]}/#{m[:file]}"
+        "https://raw.githubusercontent.com/#{m[:user]}/#{m[:repo]}/#{m[:sha1]}/#{m[:file]}"
       end
       def title
         Sanitize.fragment(URI.unescape(link).sub(/^https?\:\/\/github\.com\//, ''))

--- a/lib/onebox/mixins/git_blob_onebox.rb
+++ b/lib/onebox/mixins/git_blob_onebox.rb
@@ -158,38 +158,46 @@ module Onebox
 
             @file = m[:file]
             @lang = Onebox::FileTypeFinder.from_file_name(m[:file])
-            contents = open(self.raw_template(m), read_timeout: timeout).read
 
-            contents_lines = contents.lines           #get contents lines
-            contents_lines_size = contents_lines.size #get number of lines
+            if @lang == "stl"
 
-            cr = calc_range(m, contents_lines_size)    #calculate the range of lines for output
-            selected_one_liner = cr[:selected_one_liner] #if url is a one-liner calc_range will return it
-            from           = cr[:from]
-            to             = cr[:to]
-            @truncated     = cr[:truncated]
-            range_provided = cr[:range_provided]
-            @cr_results = cr
+              @model_file = @lang.dup
+              @raw = "https://render.githubusercontent.com/view/solid?url=" + self.raw_template(m) 
 
-            if range_provided       #if a range provided (single line or more)
-              if SHOW_LINE_NUMBER
-                lines_result = line_number_helper(contents_lines[(from - 1)..(to - 1)], from, selected_one_liner)  #print code with prefix line numbers in case range provided
-                contents = lines_result[:output]
-                @selected_lines_array = lines_result[:array]
+            else
+              contents = open(self.raw_template(m), read_timeout: timeout).read
+
+              contents_lines = contents.lines           #get contents lines
+              contents_lines_size = contents_lines.size #get number of lines
+
+              cr = calc_range(m, contents_lines_size)    #calculate the range of lines for output
+              selected_one_liner = cr[:selected_one_liner] #if url is a one-liner calc_range will return it
+              from           = cr[:from]
+              to             = cr[:to]
+              @truncated     = cr[:truncated]
+              range_provided = cr[:range_provided]
+              @cr_results = cr
+
+              if range_provided       #if a range provided (single line or more)
+                if SHOW_LINE_NUMBER
+                  lines_result = line_number_helper(contents_lines[(from - 1)..(to - 1)], from, selected_one_liner)  #print code with prefix line numbers in case range provided
+                  contents = lines_result[:output]
+                  @selected_lines_array = lines_result[:array]
+                else
+                  contents = contents_lines[(from - 1)..(to - 1)].join()
+                end
+
               else
                 contents = contents_lines[(from - 1)..(to - 1)].join()
               end
 
-            else
-              contents = contents_lines[(from - 1)..(to - 1)].join()
-            end
+              if contents.length > MAX_CHARS    #truncate content chars to limits
+                contents = contents[0..MAX_CHARS]
+                @truncated = true
+              end
 
-            if contents.length > MAX_CHARS    #truncate content chars to limits
-              contents = contents[0..MAX_CHARS]
-              @truncated = true
+              @raw = contents
             end
-
-            @raw = contents
           end
         end
 
@@ -206,7 +214,8 @@ module Onebox
             has_lines: !@selected_lines_array.nil?,
             selected_one_liner: @selected_one_liner,
             cr_results: @cr_results,
-            truncated: @truncated
+            truncated: @truncated,
+            model_file: @model_file
           }
         end
       end

--- a/templates/githubblob.mustache
+++ b/templates/githubblob.mustache
@@ -1,6 +1,13 @@
 <h4><a href="{{link}}" target="_blank">{{title}}</a></h4>
 {{^has_lines}}
+{{#model_file}}
+<iframe class="render-viewer" src="{{content}}" sandbox="allow-scripts allow-same-origin allow-top-navigation ">
+Viewer requires iframe.
+</iframe>
+{{/model_file}}
+{{^model_file}}
 <pre><code class='{{lang}}'>{{content}}</code></pre>
+{{/model_file}}
 {{/has_lines}}
 {{#has_lines}}
 {{! This is a template comment  | Sample rules for this box


### PR DESCRIPTION
Github has code for displaying stl files but the existing onebox engine would treat the file as text.

I modified the github_blob engine to put the "render.githubusercontent.com/view/solid" link in an iframe if the file type ends with stl.

You can test this using "https://github.com/nophead/Mendel90/blob/master/dibond/stls/x_motor_bracket.stl"

I've never written anything in ruby so be gentle. :)