### PR TITLE
Add frozen string literal to all the files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in onebox.gemspec

--- a/Guardfile
+++ b/Guardfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 guard :rspec, cmd: 'bundle exec rspec' do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})               { |m| "spec/lib/#{m[1]}_spec.rb" }

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,6 @@
 #!/usr/bin/env rake
+# frozen_string_literal: true
+
 require "rspec/core/rake_task"
 require 'bundler'
 

--- a/lib/onebox.rb
+++ b/lib/onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "openssl"
 require "open-uri"
 require "multi_json"

--- a/lib/onebox/engine.rb
+++ b/lib/onebox/engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     def self.included(object)

--- a/lib/onebox/engine/amazon_onebox.rb
+++ b/lib/onebox/engine/amazon_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'json'
 require "onebox/open_graph"
 

--- a/lib/onebox/engine/asciinema_onebox.rb
+++ b/lib/onebox/engine/asciinema_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class AsciinemaOnebox

--- a/lib/onebox/engine/audio_onebox.rb
+++ b/lib/onebox/engine/audio_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class AudioOnebox

--- a/lib/onebox/engine/audioboom_onebox.rb
+++ b/lib/onebox/engine/audioboom_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class AudioboomOnebox

--- a/lib/onebox/engine/bandcamp_onebox.rb
+++ b/lib/onebox/engine/bandcamp_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class BandCampOnebox

--- a/lib/onebox/engine/cloudapp_onebox.rb
+++ b/lib/onebox/engine/cloudapp_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class CloudAppOnebox

--- a/lib/onebox/engine/coub_onebox.rb
+++ b/lib/onebox/engine/coub_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class CoubOnebox

--- a/lib/onebox/engine/douban_onebox.rb
+++ b/lib/onebox/engine/douban_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class DoubanOnebox

--- a/lib/onebox/engine/five_hundred_px_onebox.rb
+++ b/lib/onebox/engine/five_hundred_px_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class FiveHundredPxOnebox

--- a/lib/onebox/engine/flickr_onebox.rb
+++ b/lib/onebox/engine/flickr_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative './opengraph_image'
 
 module Onebox

--- a/lib/onebox/engine/flickr_shortened_onebox.rb
+++ b/lib/onebox/engine/flickr_shortened_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative './opengraph_image'
 
 module Onebox

--- a/lib/onebox/engine/gfycat_onebox.rb
+++ b/lib/onebox/engine/gfycat_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class GfycatOnebox

--- a/lib/onebox/engine/giphy_onebox.rb
+++ b/lib/onebox/engine/giphy_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class GiphyOnebox

--- a/lib/onebox/engine/github_blob_onebox.rb
+++ b/lib/onebox/engine/github_blob_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../mixins/git_blob_onebox'
 
 module Onebox

--- a/lib/onebox/engine/github_commit_onebox.rb
+++ b/lib/onebox/engine/github_commit_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class GithubCommitOnebox

--- a/lib/onebox/engine/github_gist_onebox.rb
+++ b/lib/onebox/engine/github_gist_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class GithubGistOnebox

--- a/lib/onebox/engine/github_issue_onebox.rb
+++ b/lib/onebox/engine/github_issue_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class GithubIssueOnebox

--- a/lib/onebox/engine/github_pullrequest_onebox.rb
+++ b/lib/onebox/engine/github_pullrequest_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class GithubPullRequestOnebox

--- a/lib/onebox/engine/gitlab_blob_onebox.rb
+++ b/lib/onebox/engine/gitlab_blob_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../mixins/git_blob_onebox'
 
 module Onebox

--- a/lib/onebox/engine/google_calendar_onebox.rb
+++ b/lib/onebox/engine/google_calendar_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class GoogleCalendarOnebox

--- a/lib/onebox/engine/google_docs_onebox.rb
+++ b/lib/onebox/engine/google_docs_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class GoogleDocsOnebox

--- a/lib/onebox/engine/google_drive_onebox.rb
+++ b/lib/onebox/engine/google_drive_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class GoogleDriveOnebox

--- a/lib/onebox/engine/google_maps_onebox.rb
+++ b/lib/onebox/engine/google_maps_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class GoogleMapsOnebox

--- a/lib/onebox/engine/google_photos_onebox.rb
+++ b/lib/onebox/engine/google_photos_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class GooglePhotosOnebox

--- a/lib/onebox/engine/google_play_app_onebox.rb
+++ b/lib/onebox/engine/google_play_app_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class GooglePlayAppOnebox

--- a/lib/onebox/engine/html.rb
+++ b/lib/onebox/engine/html.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     module HTML

--- a/lib/onebox/engine/image_onebox.rb
+++ b/lib/onebox/engine/image_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class ImageOnebox

--- a/lib/onebox/engine/imgur_onebox.rb
+++ b/lib/onebox/engine/imgur_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class ImgurOnebox

--- a/lib/onebox/engine/instagram_onebox.rb
+++ b/lib/onebox/engine/instagram_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'htmlentities'
 
 module Onebox

--- a/lib/onebox/engine/json.rb
+++ b/lib/onebox/engine/json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     module JSON

--- a/lib/onebox/engine/kaltura_onebox.rb
+++ b/lib/onebox/engine/kaltura_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class KalturaOnebox

--- a/lib/onebox/engine/mixcloud_onebox.rb
+++ b/lib/onebox/engine/mixcloud_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class MixcloudOnebox

--- a/lib/onebox/engine/opengraph_image.rb
+++ b/lib/onebox/engine/opengraph_image.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     module OpengraphImage

--- a/lib/onebox/engine/pastebin_onebox.rb
+++ b/lib/onebox/engine/pastebin_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class PastebinOnebox

--- a/lib/onebox/engine/pdf_onebox.rb
+++ b/lib/onebox/engine/pdf_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class PdfOnebox

--- a/lib/onebox/engine/pubmed_onebox.rb
+++ b/lib/onebox/engine/pubmed_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class PubmedOnebox

--- a/lib/onebox/engine/reddit_image_onebox.rb
+++ b/lib/onebox/engine/reddit_image_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class RedditImageOnebox

--- a/lib/onebox/engine/replit_onebox.rb
+++ b/lib/onebox/engine/replit_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class ReplitOnebox

--- a/lib/onebox/engine/simplecast_onebox.rb
+++ b/lib/onebox/engine/simplecast_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class SimplecastOnebox

--- a/lib/onebox/engine/sketchfab_onebox.rb
+++ b/lib/onebox/engine/sketchfab_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class SketchFabOnebox

--- a/lib/onebox/engine/slides_onebox.rb
+++ b/lib/onebox/engine/slides_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class SlidesOnebox

--- a/lib/onebox/engine/soundcloud_onebox.rb
+++ b/lib/onebox/engine/soundcloud_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class SoundCloudOnebox

--- a/lib/onebox/engine/stack_exchange_onebox.rb
+++ b/lib/onebox/engine/stack_exchange_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class StackExchangeOnebox

--- a/lib/onebox/engine/standard_embed.rb
+++ b/lib/onebox/engine/standard_embed.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "cgi"
 require "onebox/open_graph"
 

--- a/lib/onebox/engine/steam_store_onebox.rb
+++ b/lib/onebox/engine/steam_store_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class SteamStoreOnebox

--- a/lib/onebox/engine/trello_onebox.rb
+++ b/lib/onebox/engine/trello_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class TrelloOnebox

--- a/lib/onebox/engine/twitch_clips_onebox.rb
+++ b/lib/onebox/engine/twitch_clips_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../mixins/twitch_onebox'
 
 class Onebox::Engine::TwitchClipsOnebox

--- a/lib/onebox/engine/twitch_stream_onebox.rb
+++ b/lib/onebox/engine/twitch_stream_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../mixins/twitch_onebox'
 
 class Onebox::Engine::TwitchStreamOnebox

--- a/lib/onebox/engine/twitch_video_onebox.rb
+++ b/lib/onebox/engine/twitch_video_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../mixins/twitch_onebox'
 
 class Onebox::Engine::TwitchVideoOnebox

--- a/lib/onebox/engine/twitter_status_onebox.rb
+++ b/lib/onebox/engine/twitter_status_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class TwitterStatusOnebox

--- a/lib/onebox/engine/typeform_onebox.rb
+++ b/lib/onebox/engine/typeform_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class TypeformOnebox

--- a/lib/onebox/engine/video_onebox.rb
+++ b/lib/onebox/engine/video_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class VideoOnebox

--- a/lib/onebox/engine/vimeo_onebox.rb
+++ b/lib/onebox/engine/vimeo_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class VimeoOnebox

--- a/lib/onebox/engine/wechat_mp_onebox.rb
+++ b/lib/onebox/engine/wechat_mp_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class WechatMpOnebox

--- a/lib/onebox/engine/whitelisted_generic_onebox.rb
+++ b/lib/onebox/engine/whitelisted_generic_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'htmlentities'
 
 module Onebox
@@ -255,7 +257,9 @@ module Onebox
       def rewrite_https(html)
         return unless html
         uri = URI(@url)
-        html.gsub!("http://", "https://") if WhitelistedGenericOnebox.host_matches(uri, WhitelistedGenericOnebox.rewrites)
+        if WhitelistedGenericOnebox.host_matches(uri, WhitelistedGenericOnebox.rewrites)
+          html = html.gsub("http://", "https://")
+        end
         html
       end
 

--- a/lib/onebox/engine/wikimedia_onebox.rb
+++ b/lib/onebox/engine/wikimedia_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class WikimediaOnebox

--- a/lib/onebox/engine/wikipedia_onebox.rb
+++ b/lib/onebox/engine/wikipedia_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class WikipediaOnebox
@@ -63,7 +65,7 @@ module Onebox
             end
 
             paragraph.gsub!(/\[\d+\]/mi, "")
-            text << paragraph
+            text += paragraph
             cnt += 1
           end
         end

--- a/lib/onebox/engine/wistia_onebox.rb
+++ b/lib/onebox/engine/wistia_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class WistiaOnebox

--- a/lib/onebox/engine/xkcd_onebox.rb
+++ b/lib/onebox/engine/xkcd_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class XkcdOnebox

--- a/lib/onebox/engine/youku_onebox.rb
+++ b/lib/onebox/engine/youku_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Engine
     class YoukuOnebox

--- a/lib/onebox/engine/youtube_onebox.rb
+++ b/lib/onebox/engine/youtube_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'onebox/oembed'
 
 module Onebox

--- a/lib/onebox/file_type_finder.rb
+++ b/lib/onebox/file_type_finder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module FileTypeFinder
 

--- a/lib/onebox/helpers.rb
+++ b/lib/onebox/helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Helpers
 

--- a/lib/onebox/layout.rb
+++ b/lib/onebox/layout.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "template_support"
 
 module Onebox

--- a/lib/onebox/layout_support.rb
+++ b/lib/onebox/layout_support.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module LayoutSupport
 

--- a/lib/onebox/matcher.rb
+++ b/lib/onebox/matcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   class Matcher
     def initialize(link)

--- a/lib/onebox/mixins/git_blob_onebox.rb
+++ b/lib/onebox/mixins/git_blob_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Mixins
     module GitBlobOnebox

--- a/lib/onebox/mixins/twitch_onebox.rb
+++ b/lib/onebox/mixins/twitch_onebox.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module Mixins
     module TwitchOnebox

--- a/lib/onebox/oembed.rb
+++ b/lib/onebox/oembed.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   class Oembed < OpenGraph
 

--- a/lib/onebox/open_graph.rb
+++ b/lib/onebox/open_graph.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   class OpenGraph
 

--- a/lib/onebox/preview.rb
+++ b/lib/onebox/preview.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   class Preview
     attr_reader :cache

--- a/lib/onebox/sanitize_config.rb
+++ b/lib/onebox/sanitize_config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Sanitize
   module Config
 

--- a/lib/onebox/status_check.rb
+++ b/lib/onebox/status_check.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   class StatusCheck
     def initialize(url, options = Onebox.options)

--- a/lib/onebox/template_support.rb
+++ b/lib/onebox/template_support.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module TemplateSupport
     def load_paths

--- a/lib/onebox/view.rb
+++ b/lib/onebox/view.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "template_support"
 
 module Onebox

--- a/lib/onebox/web.rb
+++ b/lib/onebox/web.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'haml'
 require 'yaml'
 require 'sinatra/base'

--- a/lib/onebox/web_helpers.rb
+++ b/lib/onebox/web_helpers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Onebox
   module WebHelpers
     def root_path

--- a/spec/lib/onebox/engine/amazon_onebox_spec.rb
+++ b/spec/lib/onebox/engine/amazon_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::AmazonOnebox do

--- a/spec/lib/onebox/engine/audio_onebox_spec.rb
+++ b/spec/lib/onebox/engine/audio_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::AudioOnebox do

--- a/spec/lib/onebox/engine/cloudapp_onebox_spec.rb
+++ b/spec/lib/onebox/engine/cloudapp_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::CloudAppOnebox do

--- a/spec/lib/onebox/engine/douban_onebox_spec.rb
+++ b/spec/lib/onebox/engine/douban_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::DoubanOnebox do

--- a/spec/lib/onebox/engine/gfycat_onebox_spec.rb
+++ b/spec/lib/onebox/engine/gfycat_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::GfycatOnebox do

--- a/spec/lib/onebox/engine/github_blob_onebox_spec.rb
+++ b/spec/lib/onebox/engine/github_blob_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::GithubBlobOnebox do

--- a/spec/lib/onebox/engine/github_commit_onebox_spec.rb
+++ b/spec/lib/onebox/engine/github_commit_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::GithubCommitOnebox do

--- a/spec/lib/onebox/engine/github_gist_onebox_spec.rb
+++ b/spec/lib/onebox/engine/github_gist_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::GithubGistOnebox do

--- a/spec/lib/onebox/engine/github_pullrequest_onebox_spec.rb
+++ b/spec/lib/onebox/engine/github_pullrequest_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::GithubPullRequestOnebox do

--- a/spec/lib/onebox/engine/gitlab_blob_onebox_spec.rb
+++ b/spec/lib/onebox/engine/gitlab_blob_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::GitlabBlobOnebox do

--- a/spec/lib/onebox/engine/google_docs_onebox_spec.rb
+++ b/spec/lib/onebox/engine/google_docs_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::GoogleDocsOnebox do

--- a/spec/lib/onebox/engine/google_drive_onebox_spec.rb
+++ b/spec/lib/onebox/engine/google_drive_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::GoogleDriveOnebox do

--- a/spec/lib/onebox/engine/google_maps_onebox_spec.rb
+++ b/spec/lib/onebox/engine/google_maps_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::GoogleMapsOnebox do

--- a/spec/lib/onebox/engine/google_photos_onebox_spec.rb
+++ b/spec/lib/onebox/engine/google_photos_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::GooglePhotosOnebox do

--- a/spec/lib/onebox/engine/google_play_app_onebox_spec.rb
+++ b/spec/lib/onebox/engine/google_play_app_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::GooglePlayAppOnebox do

--- a/spec/lib/onebox/engine/html_spec.rb
+++ b/spec/lib/onebox/engine/html_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::HTML do

--- a/spec/lib/onebox/engine/image_onebox_spec.rb
+++ b/spec/lib/onebox/engine/image_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::ImageOnebox do

--- a/spec/lib/onebox/engine/imgur_onebox_spec.rb
+++ b/spec/lib/onebox/engine/imgur_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::ImgurOnebox do

--- a/spec/lib/onebox/engine/instagram_onebox_spec.rb
+++ b/spec/lib/onebox/engine/instagram_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::InstagramOnebox do

--- a/spec/lib/onebox/engine/json_spec.rb
+++ b/spec/lib/onebox/engine/json_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::JSON do

--- a/spec/lib/onebox/engine/kaltura_onebox_spec.rb
+++ b/spec/lib/onebox/engine/kaltura_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Onebox::Engine::KalturaOnebox do

--- a/spec/lib/onebox/engine/pdf_onebox_spec.rb
+++ b/spec/lib/onebox/engine/pdf_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::PdfOnebox do

--- a/spec/lib/onebox/engine/pubmed_onebox_spec.rb
+++ b/spec/lib/onebox/engine/pubmed_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::PubmedOnebox do

--- a/spec/lib/onebox/engine/reddit_image_spec.rb
+++ b/spec/lib/onebox/engine/reddit_image_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::RedditImageOnebox do

--- a/spec/lib/onebox/engine/slides_onebox_spec.rb
+++ b/spec/lib/onebox/engine/slides_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::SlidesOnebox do

--- a/spec/lib/onebox/engine/stack_exchange_onebox_spec.rb
+++ b/spec/lib/onebox/engine/stack_exchange_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Onebox::Engine::StackExchangeOnebox do

--- a/spec/lib/onebox/engine/trello_onebox_spec.rb
+++ b/spec/lib/onebox/engine/trello_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::TrelloOnebox do

--- a/spec/lib/onebox/engine/twitch_clips_onebox_spec.rb
+++ b/spec/lib/onebox/engine/twitch_clips_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Onebox::Engine::TwitchClipsOnebox do

--- a/spec/lib/onebox/engine/twitch_stream_onebox_spec.rb
+++ b/spec/lib/onebox/engine/twitch_stream_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Onebox::Engine::TwitchStreamOnebox do

--- a/spec/lib/onebox/engine/twitch_video_onebox_spec.rb
+++ b/spec/lib/onebox/engine/twitch_video_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Onebox::Engine::TwitchVideoOnebox do

--- a/spec/lib/onebox/engine/twitter_status_onebox_spec.rb
+++ b/spec/lib/onebox/engine/twitter_status_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::TwitterStatusOnebox do

--- a/spec/lib/onebox/engine/typeform_onebox_spec.rb
+++ b/spec/lib/onebox/engine/typeform_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Onebox::Engine::TypeformOnebox do

--- a/spec/lib/onebox/engine/video_onebox_spec.rb
+++ b/spec/lib/onebox/engine/video_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::VideoOnebox do

--- a/spec/lib/onebox/engine/wechat_mp_onebox_spec.rb
+++ b/spec/lib/onebox/engine/wechat_mp_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::WechatMpOnebox do

--- a/spec/lib/onebox/engine/whitelisted_generic_onebox_spec.rb
+++ b/spec/lib/onebox/engine/whitelisted_generic_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::WhitelistedGenericOnebox do

--- a/spec/lib/onebox/engine/wikimedia_onebox_spec.rb
+++ b/spec/lib/onebox/engine/wikimedia_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::WikimediaOnebox do

--- a/spec/lib/onebox/engine/wikipedia_onebox_spec.rb
+++ b/spec/lib/onebox/engine/wikipedia_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::WikipediaOnebox do

--- a/spec/lib/onebox/engine/xkcd_spec.rb
+++ b/spec/lib/onebox/engine/xkcd_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine::XkcdOnebox do

--- a/spec/lib/onebox/engine/youku_onebox_spec.rb
+++ b/spec/lib/onebox/engine/youku_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Onebox::Engine::YoukuOnebox do

--- a/spec/lib/onebox/engine/youtube_onebox_spec.rb
+++ b/spec/lib/onebox/engine/youtube_onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Onebox::Engine::YoutubeOnebox do

--- a/spec/lib/onebox/engine_spec.rb
+++ b/spec/lib/onebox/engine_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Engine do

--- a/spec/lib/onebox/helpers_spec.rb
+++ b/spec/lib/onebox/helpers_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Onebox::Helpers do

--- a/spec/lib/onebox/layout_spec.rb
+++ b/spec/lib/onebox/layout_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Layout do

--- a/spec/lib/onebox/matcher_spec.rb
+++ b/spec/lib/onebox/matcher_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 class TestEngine

--- a/spec/lib/onebox/oembed_spec.rb
+++ b/spec/lib/onebox/oembed_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "onebox/oembed"
 

--- a/spec/lib/onebox/open_graph_spec.rb
+++ b/spec/lib/onebox/open_graph_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 require "onebox/open_graph"
 

--- a/spec/lib/onebox/preview_spec.rb
+++ b/spec/lib/onebox/preview_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::Preview do

--- a/spec/lib/onebox/status_check_spec.rb
+++ b/spec/lib/onebox/status_check_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox::StatusCheck do

--- a/spec/lib/onebox_spec.rb
+++ b/spec/lib/onebox_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe Onebox do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rspec"
 require "pry"
 require "fakeweb"

--- a/spec/support/html_spec_helper.rb
+++ b/spec/support/html_spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module HTMLSpecHelper
   def fake(uri, response, verb = :get)
     FakeWeb.register_uri(verb, uri, response: header(response))


### PR DESCRIPTION
Since we inherit the rubocop file from discourse/discourse we need to add the `frozen_string_literal: true` support.