### PR TITLE
Deprioritize Twitter card in generic onebox

### DIFF
--- a/lib/onebox/engine/whitelisted_generic_onebox.rb
+++ b/lib/onebox/engine/whitelisted_generic_onebox.rb
@@ -265,12 +265,12 @@ module Onebox
       end
 
       def generic_html
-        return card_html     if is_card?
         return article_html  if is_article?
         return video_html    if is_video?
         return image_html    if is_image?
         return embedded_html if is_embedded?
         return article_html  if has_text?
+        return card_html     if is_card?
       end
 
       def is_card?


### PR DESCRIPTION
We prefer to render our own video/image, rather than loading an iframe. For Facebook videos, the twitter card iframe contains an auto-playing video which is not user friendly. With this change, the facebook video will be displayed in a native `<video>` player, without autoplay.