### PR TITLE
Added enablejsapi param

### DIFF
--- a/lib/onebox/engine/youtube_onebox.rb
+++ b/lib/onebox/engine/youtube_onebox.rb
@@ -134,6 +134,9 @@ module Onebox
         # https://developers.google.com/youtube/player_parameters#rel
         p['rel'] = 0 if params.include?('rel')
 
+        # https://developers.google.com/youtube/player_parameters#enablejsapi
+        p['enablejsapi'] = params['enablejsapi'] if params.include?('enablejsapi')
+
         URI.encode_www_form(p)
       end
 


### PR DESCRIPTION
Added the ability to pass in the param enablejsapi. This is needed for tracking within Tag Manager.

https://developers.google.com/youtube/player_parameters#enablejsapi