### PR TITLE
FIX: Follow redirect returns url if response code is 200

### DIFF
--- a/lib/onebox/engine/google_maps_onebox.rb
+++ b/lib/onebox/engine/google_maps_onebox.rb
@@ -169,8 +169,9 @@ module Onebox
           http = Net::HTTP.start(uri.host, uri.port,
             use_ssl: uri.scheme == 'https', open_timeout: timeout, read_timeout: timeout)
           response = http.head(uri.path)
-          raise "unexpected response code #{response.code}" unless %w(301 302).include?(response.code)
-          @url = response["Location"]
+
+          raise "unexpected response code #{response.code}" unless %w(200 301 302).include?(response.code)
+          @url = response.code == "200" ? uri.to_s : response["Location"]
         ensure
           http.finish rescue nil
         end


### PR DESCRIPTION
This method, `follow_redirect!` is being called on urls that do not need to redirect, and return 200 status. If that is the case, just return the uri!

![Screenshot from 2019-10-21 10-20-51](https://user-images.githubusercontent.com/16214023/67218941-d56c8080-f3ec-11e9-9641-cc7ca7a18e1a.png)
