### PR TITLE
Fix for gfycat onebox in email

### DIFF
--- a/lib/onebox/engine/gfycat_onebox.rb
+++ b/lib/onebox/engine/gfycat_onebox.rb
@@ -41,6 +41,7 @@ module Onebox
               </p>
 
             </article>
+            <div style="clear: both"></div>
           </aside>
         HTML
       end


### PR DESCRIPTION
Trying to fix this issue in email where the gfycat preview image float isn't cleared and extends outside the container...

<img width="439" alt="Screen Shot 2019-11-06 at 4 10 17 PM" src="https://user-images.githubusercontent.com/1681963/68338725-1a610a00-00b1-11ea-931c-8e93b4c27999.png">
