### PR TITLE
DEV: Replace custom uri_encode logic with Addressable

### DIFF
--- a/spec/lib/onebox/helpers_spec.rb
+++ b/spec/lib/onebox/helpers_spec.rb
@@ -93,5 +93,6 @@ RSpec.describe Onebox::Helpers do
 
     it { expect(described_class.uri_encode("https://example.com/random%2Bpath?q=random%2Bquery")).to eq("https://example.com/random%2Bpath?q=random%2Bquery") }
     it { expect(described_class.uri_encode("https://glitch.com/edit/#!/equinox-watch")).to eq("https://glitch.com/edit/#!/equinox-watch") }
+    it { expect(described_class.uri_encode("https://gitpod.io/#https://github.com/eclipse-theia/theia")).to eq("https://gitpod.io/#https://github.com/eclipse-theia/theia") }
   end
 end


### PR DESCRIPTION
Since #418 introduced the `addressable` gem as a runtime dependency, it's now possible to replace all custom URI encoding logic with addressable's methods.

~~This change is non-breaking, at least as far as the tests go, but it is possible that some characters (that aren't covered by specs) are now escaped and they weren't before (or the other way around).~~

It does handle some characters differently - e.g. it now doesn't escape URLs in URI fragments (see the added test). Previous escaping behavior was reported as an issue in Discourse.