### PR TITLE
Add JovianML to whitelist

### DIFF
--- a/lib/onebox/engine/whitelisted_generic_onebox.rb
+++ b/lib/onebox/engine/whitelisted_generic_onebox.rb
@@ -73,6 +73,7 @@ module Onebox
           imdb.com
           indiatimes.com
           itunes.apple.com
+          jovian.ml
           khanacademy.org
           kickstarter.com
           kinomap.com


### PR DESCRIPTION
added JovianML as Embed provider

[Jovian](https://jovian.ml) makes Jupyter notebooks shareable, commentable and reproducible.

[Documentation](https://jovian.ml/docs/)
[Tutorial/Getting started](https://jovian.ml/aakashns/jovian-tutorial)