### PR TITLE
Guard against nil google doc description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /.idea
 .config
 .yardoc
+.ruby-version
 InstalledFiles
 _yardoc
 coverage

--- a/lib/onebox/engine/google_docs_onebox.rb
+++ b/lib/onebox/engine/google_docs_onebox.rb
@@ -26,9 +26,16 @@ module Onebox
 
       def data
         og_data = get_og_data
+
+        if og_data[:description].present?
+          description = Onebox::Helpers.truncate(og_data[:description], 250)
+        else
+          description = "This #{shorttype.to_s.chop.capitalize} is private"
+        end
+
         result = { link: link,
                    title: og_data[:title] || "Google #{shorttype.to_s.capitalize}",
-                   description: Onebox::Helpers.truncate(og_data[:description], 250) || "This #{shorttype.to_s.chop.capitalize} is private",
+                   description: description,
                    type: shorttype
                  }
         result


### PR DESCRIPTION
This PR does two things:

* We're seeing a `NoMethodError` exception being raised when `og_data.description` is `nil` 
* Also includes `StandardEmbed` in the google docs engine to retrieve open graph data in a standard way by calling `get_opengraph`