### PR TITLE
FIX: Fix handling of multi-cookie responses

### DIFF
--- a/spec/support/html_spec_helper.rb
+++ b/spec/support/html_spec_helper.rb
@@ -2,10 +2,10 @@
 
 module HTMLSpecHelper
   def fake(uri, response, verb = :get)
-    FakeWeb.register_uri(verb, uri, response: header(response))
+    FakeWeb.register_uri(verb, uri, response: http_ok(response))
   end
 
-  def header(html)
+  def http_ok(html)
     "HTTP/1.1 200 OK\n\n#{html}"
   end
 


### PR DESCRIPTION
FIX: Correctly parse relative redirects using Addressable

Also rename 'header' to 'redir_header' to deconflict with 'headers' parameter

---

We were slamming cookies together, such that the last parameter of one cookie would bleed into the name of the next. Medium.com was not happy with this arrangement.