### PR TITLE
FEATURE: Add more control of iframe embeds

### DIFF
--- a/lib/onebox/engine/bandcamp_onebox.rb
+++ b/lib/onebox/engine/bandcamp_onebox.rb
@@ -8,6 +8,7 @@ module Onebox
 
       matches_regexp(/^https?:\/\/.*\.bandcamp\.com\/(album|track)\//)
       always_https
+      requires_iframe_origins "https://bandcamp.com"
 
       def placeholder_html
         og = get_opengraph

--- a/lib/onebox/engine/facebook_media_onebox.rb
+++ b/lib/onebox/engine/facebook_media_onebox.rb
@@ -8,6 +8,7 @@ module Onebox
 
       matches_regexp(/^https?:\/\/.*\.facebook\.com\/(\w+)\/(videos|\?).*/)
       always_https
+      requires_iframe_origins "https://www.facebook.com"
 
       def to_html
         metadata = get_twitter

--- a/lib/onebox/engine/google_calendar_onebox.rb
+++ b/lib/onebox/engine/google_calendar_onebox.rb
@@ -7,6 +7,7 @@ module Onebox
 
       matches_regexp /^(https?:)?\/\/((www|calendar)\.google\.[\w.]{2,}|goo\.gl)\/calendar\/.+$/
       always_https
+      requires_iframe_origins "https://calendar.google.com"
 
       def to_html
         url = @url.split('&').first

--- a/lib/onebox/engine/google_maps_onebox.rb
+++ b/lib/onebox/engine/google_maps_onebox.rb
@@ -23,6 +23,8 @@ module Onebox
 
       always_https
 
+      requires_iframe_origins("https://maps.google.com", "https://google.com")
+
       # Matches shortened Google Maps URLs
       matches_regexp :short,      %r"^(https?:)?//goo\.gl/maps/"
 

--- a/lib/onebox/engine/kaltura_onebox.rb
+++ b/lib/onebox/engine/kaltura_onebox.rb
@@ -8,6 +8,7 @@ module Onebox
 
       always_https
       matches_regexp(/^https?:\/\/[a-z0-9]+\.kaltura\.com\/id\/[a-zA-Z0-9]+/)
+      requires_iframe_origins "https://*.kaltura.com"
 
       def preview_html
         og = get_opengraph

--- a/lib/onebox/engine/sketchfab_onebox.rb
+++ b/lib/onebox/engine/sketchfab_onebox.rb
@@ -8,6 +8,7 @@ module Onebox
 
       matches_regexp(/^https?:\/\/sketchfab\.com\/(?:models\/|3d-models\/(?:[^\/\s]+-)?)([a-z0-9]{32})/)
       always_https
+      requires_iframe_origins("https://sketchfab.com")
 
       def to_html
         og = get_opengraph

--- a/lib/onebox/engine/slides_onebox.rb
+++ b/lib/onebox/engine/slides_onebox.rb
@@ -7,10 +7,11 @@ module Onebox
       include StandardEmbed
 
       matches_regexp(/^https?:\/\/slides\.com\/[\p{Alnum}_\-]+\/[\p{Alnum}_\-]+$/)
+      requires_iframe_origins "https://slides.com"
 
       def to_html
         <<-HTML
-          <iframe src="//slides.com#{uri.path}/embed?style=light"
+          <iframe src="https://slides.com#{uri.path}/embed?style=light"
                   width="576"
                   height="420"
                   scrolling="no"

--- a/lib/onebox/engine/steam_store_onebox.rb
+++ b/lib/onebox/engine/steam_store_onebox.rb
@@ -8,6 +8,7 @@ module Onebox
 
       always_https
       matches_regexp(/^https?:\/\/store\.steampowered\.com\/app\/\d+/)
+      requires_iframe_origins "https://store.steampowered.com"
 
       def placeholder_html
         og = get_opengraph

--- a/lib/onebox/engine/trello_onebox.rb
+++ b/lib/onebox/engine/trello_onebox.rb
@@ -7,6 +7,7 @@ module Onebox
       include StandardEmbed
 
       matches_regexp(/^https:\/\/trello\.com\/[bc]\/\W*/)
+      requires_iframe_origins "https://trello.com"
       always_https
 
       def to_html

--- a/lib/onebox/engine/twitch_clips_onebox.rb
+++ b/lib/onebox/engine/twitch_clips_onebox.rb
@@ -9,6 +9,8 @@ class Onebox::Engine::TwitchClipsOnebox
   end
   include Onebox::Mixins::TwitchOnebox
 
+  requires_iframe_origins "https://clips.twitch.tv"
+
   def query_params
     "clip=#{twitch_id}"
   end

--- a/lib/onebox/engine/typeform_onebox.rb
+++ b/lib/onebox/engine/typeform_onebox.rb
@@ -6,6 +6,7 @@ module Onebox
       include Engine
 
       matches_regexp(/^https?:\/\/[a-z0-9\-_]+\.typeform\.com\/to\/[a-zA-Z0-9]+/)
+      requires_iframe_origins "https://*.typeform.com"
       always_https
 
       def to_html

--- a/lib/onebox/engine/vimeo_onebox.rb
+++ b/lib/onebox/engine/vimeo_onebox.rb
@@ -7,6 +7,7 @@ module Onebox
       include StandardEmbed
 
       matches_regexp(/^https?:\/\/(www\.)?vimeo\.com\/\d+/)
+      requires_iframe_origins "https://player.vimeo.com"
       always_https
 
       WIDTH  ||= 640

--- a/lib/onebox/engine/wistia_onebox.rb
+++ b/lib/onebox/engine/wistia_onebox.rb
@@ -7,6 +7,7 @@ module Onebox
       include StandardEmbed
 
       matches_regexp(/https?:\/\/(.+)?(wistia.com|wi.st)\/(medias|embed)\/.*/)
+      requires_iframe_origins "https://fast.wistia.com"
       always_https
 
       def to_html

--- a/lib/onebox/engine/youku_onebox.rb
+++ b/lib/onebox/engine/youku_onebox.rb
@@ -7,6 +7,7 @@ module Onebox
       include HTML
 
       matches_regexp(/^(https?:\/\/)?([\da-z\.-]+)(youku.com\/)(.)+\/?$/)
+      requires_iframe_origins "https://player.youku.com"
 
       # Try to get the video ID. Works for URLs of the form:
       # * http://v.youku.com/v_show/id_XNjM3MzAxNzc2.html

--- a/lib/onebox/engine/youtube_onebox.rb
+++ b/lib/onebox/engine/youtube_onebox.rb
@@ -7,6 +7,7 @@ module Onebox
       include StandardEmbed
 
       matches_regexp(/^https?:\/\/(?:www\.)?(?:m\.)?(?:youtube\.com|youtu\.be)\/.+$/)
+      requires_iframe_origins "https://www.youtube.com"
       always_https
 
       WIDTH  ||= 480

--- a/lib/onebox/matcher.rb
+++ b/lib/onebox/matcher.rb
@@ -2,8 +2,9 @@
 
 module Onebox
   class Matcher
-    def initialize(link)
+    def initialize(link, options = {})
       @url = link
+      @options = options
     end
 
     def ordered_engines
@@ -16,9 +17,14 @@ module Onebox
       uri = URI(@url)
       return unless uri.port.nil? || Onebox.options.allowed_ports.include?(uri.port)
       return unless uri.scheme.nil? || Onebox.options.allowed_schemes.include?(uri.scheme)
-      ordered_engines.find { |engine| engine === uri }
+      ordered_engines.find { |engine| engine === uri && has_allowed_iframe_origins?(engine) }
     rescue URI::InvalidURIError
       nil
+    end
+
+    def has_allowed_iframe_origins?(engine)
+      allowed_regexes = @options[:allowed_iframe_regexes] || []
+      engine.iframe_origins.all? { |o| allowed_regexes.any? { |r| o =~ r } }
     end
   end
 end

--- a/lib/onebox/mixins/twitch_onebox.rb
+++ b/lib/onebox/mixins/twitch_onebox.rb
@@ -7,6 +7,7 @@ module Onebox
       def self.included(klass)
         klass.include(Onebox::Engine)
         klass.matches_regexp(klass.twitch_regexp)
+        klass.requires_iframe_origins "https://player.twitch.tv"
         klass.include(InstanceMethods)
       end
 
@@ -25,7 +26,7 @@ module Onebox
 
         def to_html
           <<~HTML
-          <iframe src="//#{base_url}#{query_params}&parent=#{options[:hostname]}&autoplay=false" width="620" height="378" frameborder="0" style="overflow: hidden;" scrolling="no" allowfullscreen="allowfullscreen"></iframe>
+          <iframe src="https://#{base_url}#{query_params}&parent=#{options[:hostname]}&autoplay=false" width="620" height="378" frameborder="0" style="overflow: hidden;" scrolling="no" allowfullscreen="allowfullscreen"></iframe>
           HTML
         end
       end

--- a/lib/onebox/preview.rb
+++ b/lib/onebox/preview.rb
@@ -7,10 +7,14 @@ module Onebox
     client_exception = defined?(Net::HTTPClientException) ? Net::HTTPClientException : Net::HTTPServerException
     WEB_EXCEPTIONS ||= [client_exception, OpenURI::HTTPError, Timeout::Error, Net::HTTPError, Errno::ECONNREFUSED]
 
-    def initialize(link, parameters = Onebox.options)
+    def initialize(link, options = Onebox.options)
       @url = link
-      @options = parameters
-      @engine_class = Matcher.new(@url).oneboxed
+      @options = options.dup
+
+      allowed_origins = @options[:allowed_iframe_origins] || Onebox::Engine.all_iframe_origins
+      @options[:allowed_iframe_regexes] = Engine.origins_to_regexes(allowed_origins)
+
+      @engine_class = Matcher.new(@url, @options).oneboxed
     end
 
     def to_s
@@ -63,7 +67,10 @@ module Onebox
     end
 
     def sanitize(html)
-      Sanitize.fragment(html, @options[:sanitize_config] || Sanitize::Config::ONEBOX)
+      config = @options[:sanitize_config] || Sanitize::Config::ONEBOX
+      config = config.merge(allowed_iframe_regexes: @options[:allowed_iframe_regexes])
+
+      Sanitize.fragment(html, config)
     end
 
     def engine

--- a/lib/onebox/version.rb
+++ b/lib/onebox/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Onebox
-  VERSION = "2.0.2"
+  VERSION = "2.1.0"
 end

--- a/spec/lib/onebox/engine/twitch_clips_onebox_spec.rb
+++ b/spec/lib/onebox/engine/twitch_clips_onebox_spec.rb
@@ -7,7 +7,7 @@ describe Onebox::Engine::TwitchClipsOnebox do
   let(:options) { { hostname: hostname } }
 
   it "has the iframe with the correct channel" do
-    expect(Onebox.preview('https://clips.twitch.tv/FunVastGalagoKlappa', options).to_s).to match(/<iframe src="\/\/clips\.twitch\.tv\/embed\?clip=FunVastGalagoKlappa&amp;parent=#{hostname}/)
+    expect(Onebox.preview('https://clips.twitch.tv/FunVastGalagoKlappa', options).to_s).to match(/<iframe src="https:\/\/clips\.twitch\.tv\/embed\?clip=FunVastGalagoKlappa&amp;parent=#{hostname}/)
   end
 
 end

--- a/spec/lib/onebox/engine/twitch_stream_onebox_spec.rb
+++ b/spec/lib/onebox/engine/twitch_stream_onebox_spec.rb
@@ -7,11 +7,11 @@ describe Onebox::Engine::TwitchStreamOnebox do
   let(:options) { { hostname: hostname } }
 
   it "has the iframe with the correct channel" do
-    expect(Onebox.preview('https://www.twitch.tv/theduckie908', options).to_s).to match(/<iframe src="\/\/player\.twitch\.tv\/\?channel=theduckie908&amp;parent=#{hostname}/)
+    expect(Onebox.preview('https://www.twitch.tv/theduckie908', options).to_s).to match(/<iframe src="https:\/\/player\.twitch\.tv\/\?channel=theduckie908&amp;parent=#{hostname}/)
   end
 
   it "works in the twitch new interface/url" do
-    expect(Onebox.preview('https://go.twitch.tv/admiralbulldog', options).to_s).to match(/<iframe src="\/\/player\.twitch\.tv\/\?channel=admiralbulldog&amp;parent=#{hostname}/)
+    expect(Onebox.preview('https://go.twitch.tv/admiralbulldog', options).to_s).to match(/<iframe src="https:\/\/player\.twitch\.tv\/\?channel=admiralbulldog&amp;parent=#{hostname}/)
   end
 
 end

--- a/spec/lib/onebox/engine/twitch_video_onebox_spec.rb
+++ b/spec/lib/onebox/engine/twitch_video_onebox_spec.rb
@@ -7,6 +7,6 @@ describe Onebox::Engine::TwitchVideoOnebox do
   let(:options) { { hostname: hostname } }
 
   it "has the iframe with the correct channel" do
-    expect(Onebox.preview('https://www.twitch.tv/videos/140675974', options).to_s).to match(/<iframe src="\/\/player\.twitch\.tv\/\?video=v140675974&amp;parent=#{hostname}/)
+    expect(Onebox.preview('https://www.twitch.tv/videos/140675974', options).to_s).to match(/<iframe src="https:\/\/player\.twitch\.tv\/\?video=v140675974&amp;parent=#{hostname}/)
   end
 end

--- a/spec/lib/onebox/matcher_spec.rb
+++ b/spec/lib/onebox/matcher_spec.rb
@@ -6,15 +6,19 @@ class TestEngine
   def self.===(uri)
     true
   end
+
+  def self.iframe_origins
+    ["https://example.com", "https://example2.com"]
+  end
 end
 
 describe Onebox::Matcher do
-
+  let(:opts) { { allowed_iframe_regexes: [/.*/] } }
   describe "oneboxed" do
 
     describe "with a path" do
       let(:url) { "http://party.time.made.up-url.com/beep/boop" }
-      let(:matcher) { Onebox::Matcher.new(url) }
+      let(:matcher) { Onebox::Matcher.new(url, opts) }
 
       it "finds an engine" do
         allow(matcher).to receive(:ordered_engines).and_return([TestEngine])
@@ -24,7 +28,7 @@ describe Onebox::Matcher do
 
     describe "without a path" do
       let(:url) { "http://party.time.made.up-url.com/" }
-      let(:matcher) { Onebox::Matcher.new(url) }
+      let(:matcher) { Onebox::Matcher.new(url, opts) }
 
       it "doesn't find an engine" do
         allow(matcher).to receive(:ordered_engines).and_return([TestEngine])
@@ -34,7 +38,7 @@ describe Onebox::Matcher do
 
     describe "without a path but has a query string" do
       let(:url) { "http://party.time.made.up-url.com/?article_id=1234" }
-      let(:matcher) { Onebox::Matcher.new(url) }
+      let(:matcher) { Onebox::Matcher.new(url, opts) }
 
       it "finds an engine" do
         allow(matcher).to receive(:ordered_engines).and_return([TestEngine])
@@ -44,7 +48,7 @@ describe Onebox::Matcher do
 
     describe "without a path but has a fragment string" do
       let(:url) { "http://party.time.made.up-url.com/#article_id=1234" }
-      let(:matcher) { Onebox::Matcher.new(url) }
+      let(:matcher) { Onebox::Matcher.new(url, opts) }
 
       it "finds an engine" do
         allow(matcher).to receive(:ordered_engines).and_return([TestEngine])
@@ -55,7 +59,7 @@ describe Onebox::Matcher do
     describe "with a allowlisted port/scheme" do
       %w{http://example.com https://example.com http://example.com:80 //example.com}.each do |url|
         it "finds an engine for '#{url}'" do
-          matcher = Onebox::Matcher.new(url)
+          matcher = Onebox::Matcher.new(url, opts)
           allow(matcher).to receive(:ordered_engines).and_return([TestEngine])
           expect(matcher.oneboxed).not_to be_nil
         end
@@ -65,10 +69,36 @@ describe Onebox::Matcher do
     describe "without a allowlisted port/scheme" do
       %w{http://example.com:21 ftp://example.com}.each do |url|
         it "doesn't find an engine for '#{url}'" do
-          matcher = Onebox::Matcher.new(url)
+          matcher = Onebox::Matcher.new(url, opts)
           allow(matcher).to receive(:ordered_engines).and_return([TestEngine])
           expect(matcher.oneboxed).to be_nil
         end
+      end
+    end
+
+    describe "with restricted iframe domains" do
+      it "finds an engine when wildcard allowed" do
+        matcher = Onebox::Matcher.new("https://example.com", allowed_iframe_regexes: [/.*/])
+        allow(matcher).to receive(:ordered_engines).and_return([TestEngine])
+        expect(matcher.oneboxed).not_to be_nil
+      end
+
+      it "doesn't find an engine when nothing allowed" do
+        matcher = Onebox::Matcher.new("https://example.com", allowed_iframe_regexes: [])
+        allow(matcher).to receive(:ordered_engines).and_return([TestEngine])
+        expect(matcher.oneboxed).to be_nil
+      end
+
+      it "doesn't find an engine when only some subdomains are allowed" do
+        matcher = Onebox::Matcher.new("https://example.com", allowed_iframe_regexes: Onebox::Engine.origins_to_regexes(["https://example.com"]))
+        allow(matcher).to receive(:ordered_engines).and_return([TestEngine])
+        expect(matcher.oneboxed).to be_nil
+      end
+
+      it "finds an engine when all required domains are allowed" do
+        matcher = Onebox::Matcher.new("https://example.com", allowed_iframe_regexes: Onebox::Engine.origins_to_regexes(["https://example.com", "https://example2.com"]))
+        allow(matcher).to receive(:ordered_engines).and_return([TestEngine])
+        expect(matcher.oneboxed).not_to be_nil
       end
     end
 

--- a/spec/lib/onebox/preview_spec.rb
+++ b/spec/lib/onebox/preview_spec.rb
@@ -73,4 +73,34 @@ describe Onebox::Preview do
 
   end
 
+  describe "iframe sanitizer" do
+    let(:iframe_html) { "<iframe src='https://thirdparty.example.com'>" }
+
+    it "sanitizes iframes from unknown origins" do
+      preview = described_class.new(preview_url)
+      allow(preview).to receive(:engine_html) { iframe_html }
+
+      result = preview.to_s
+      expect(result).not_to include(' src="https://thirdparty.example.com"')
+      expect(result).to include(' data-unsanitized-src="https://thirdparty.example.com"')
+    end
+
+    it "allows allowed origins" do
+      preview = described_class.new(preview_url, allowed_iframe_origins: ["https://thirdparty.example.com"])
+      allow(preview).to receive(:engine_html) { iframe_html }
+
+      result = preview.to_s
+      expect(result).to include ' src="https://thirdparty.example.com"'
+    end
+
+    it "allows wildcard allowed origins" do
+      preview = described_class.new(preview_url, allowed_iframe_origins: ["https://*.example.com"])
+      allow(preview).to receive(:engine_html) { iframe_html }
+
+      result = preview.to_s
+      expect(result).to include ' src="https://thirdparty.example.com"'
+    end
+
+  end
+
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,7 +43,7 @@ shared_examples_for "an engine" do
   end
 
   it "correctly matches the url" do
-    onebox = Onebox::Matcher.new(link).oneboxed
+    onebox = Onebox::Matcher.new(link, { allowed_iframe_regexes: [/.*/] }).oneboxed
     expect(onebox).to be(described_class)
   end
 


### PR DESCRIPTION
All onebox engines now define their desired iframe domains using `requires_iframe_origins`

Consumers can choose to pass an array of `allowed_iframe_origins` in `options`. Engines which require iframe origins not included in the list will be skipped. The sanitizer will also strip all iframes which are not in the allowed list. If `allowed_iframe_origins` is unspecified, all required_iframe_origins will be allowed.