### PR TITLE
FIX: raise error if no data available to Instagram engine

### DIFF
--- a/lib/onebox/engine/instagram_onebox.rb
+++ b/lib/onebox/engine/instagram_onebox.rb
@@ -16,6 +16,8 @@ module Onebox
 
       def data
         oembed = get_oembed
+        raise "No oEmbed data found. Ensure 'facebook_app_access_token' is valid" if oembed.data.empty?
+
         permalink = clean_url.gsub("/#{oembed.author_name}/", "/")
 
         { link: permalink,


### PR DESCRIPTION
Raise an error if no oembed.data is found (e.g., if you have an invalid token). This will make the onebox generation fail, and return an empty onebox. Discourse itself will fallback to using the original link if the onebox is empty.