### PR TITLE
FIX: Simplify how we link to github folders

### DIFF
--- a/lib/onebox/engine/github_folder_onebox.rb
+++ b/lib/onebox/engine/github_folder_onebox.rb
@@ -45,8 +45,7 @@ module Onebox
         end
 
         {
-          link: og.url,
-          path_link: url,
+          link: url,
           image: og.image,
           title: Onebox::Helpers.truncate(title, 250),
           path: display_path,

--- a/lib/onebox/version.rb
+++ b/lib/onebox/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Onebox
-  VERSION = "2.1.8"
+  VERSION = "2.1.9"
 end

--- a/spec/lib/onebox/engine/github_folder_onebox_spec.rb
+++ b/spec/lib/onebox/engine/github_folder_onebox_spec.rb
@@ -38,7 +38,7 @@ describe Onebox::Engine::GithubFolderOnebox do
     end
 
     it "extracts subtitles when linking to docs" do
-      expect(@onebox.to_html).to include("<a href='https://github.com/discourse/discourse' target=\"_blank\" rel=\"noopener\">discourse/discourse - Setting up Discourse</a>")
+      expect(@onebox.to_html).to include("<a href='https://github.com/discourse/discourse#setting-up-discourse' target=\"_blank\" rel=\"noopener\">discourse/discourse - Setting up Discourse</a>")
     end
   end
 

--- a/templates/githubfolder.mustache
+++ b/templates/githubfolder.mustache
@@ -3,7 +3,7 @@
 <h3><a href='{{link}}' target="_blank" rel="noopener">{{title}}</a></h3>
 
 {{#path}}
-<p><a href='{{path_link}}' target="_blank" rel="noopener">{{path}}</a></p>
+<p><a href='{{link}}' target="_blank" rel="noopener">{{path}}</a></p>
 {{/path}}
 
 {{#description}}


### PR DESCRIPTION
Always use the original URL, which will retain the fragment if it was originally present.

Previously, the original URL with fragment would only be included if you were deep linking to a non-root folder.