### PR TITLE
FEATURE: support Instagram TV links

### DIFF
--- a/lib/onebox/engine/instagram_onebox.rb
+++ b/lib/onebox/engine/instagram_onebox.rb
@@ -7,11 +7,11 @@ module Onebox
       include StandardEmbed
       include LayoutSupport
 
-      matches_regexp(/^https?:\/\/(?:www\.)?(?:instagram\.com|instagr\.am)\/?(?:.*)\/p\/[a-zA-Z\d_-]+/)
+      matches_regexp(/^https?:\/\/(?:www\.)?(?:instagram\.com|instagr\.am)\/?(?:.*)\/(?:p|tv)\/[a-zA-Z\d_-]+/)
       always_https
 
       def clean_url
-        url.scan(/^https?:\/\/(?:www\.)?(?:instagram\.com|instagr\.am)\/?(?:.*)\/p\/[a-zA-Z\d_-]+/).flatten.first
+        url.scan(/^https?:\/\/(?:www\.)?(?:instagram\.com|instagr\.am)\/?(?:.*)\/(?:p|tv)\/[a-zA-Z\d_-]+/).flatten.first
       end
 
       def data

--- a/spec/lib/onebox/engine/instagram_onebox_spec.rb
+++ b/spec/lib/onebox/engine/instagram_onebox_spec.rb
@@ -18,6 +18,12 @@ describe Onebox::Engine::InstagramOnebox do
     expect(onebox_klass.name).to eq(described_class.name)
   end
 
+  it 'oneboxes tv links' do
+    tv_link = "https://www.instagram.com/tv/CIlM7UzMgXO/?hl=en"
+    onebox_klass = Onebox::Matcher.new(tv_link).oneboxed
+    expect(onebox_klass.name).to eq(described_class.name)
+  end
+
   context 'with access token' do
     let(:api_link) { "https://graph.facebook.com/v9.0/instagram_oembed?url=#{link}&access_token=#{access_token}" }
 


### PR DESCRIPTION
Instagram TV (or ‘IGTV’) links should be processed by the Instagram Onebox Engine. This means the data will be fetched via Instagram’s official oEmbed endpoint and, if an access token is configured, will not be subject to login redirects, etc.