### PR TITLE
FIX: Validate format of links

### DIFF
--- a/lib/onebox/engine/allowlisted_generic_onebox.rb
+++ b/lib/onebox/engine/allowlisted_generic_onebox.rb
@@ -227,8 +227,10 @@ module Onebox
           d[:image] = d[:image_secure_url] || d[:image_url] || d[:thumbnail_url] || d[:image]
           d[:image] = Onebox::Helpers::get_absolute_image_url(d[:image], @url)
           d[:image] = Onebox::Helpers::normalize_url_for_output(html_entities.decode(d[:image]))
+          d[:image] = nil if Onebox::Helpers.blank?(d[:image])
 
           d[:video] = d[:video_secure_url] || d[:video_url] || d[:video]
+          d[:video] = nil if Onebox::Helpers.blank?(d[:video])
 
           d[:published_time] = d[:article_published_time] unless Onebox::Helpers.blank?(d[:article_published_time])
           if !Onebox::Helpers.blank?(d[:published_time])

--- a/lib/onebox/helpers.rb
+++ b/lib/onebox/helpers.rb
@@ -180,7 +180,7 @@ module Onebox
       url.gsub!(/[^\w\-`.~:\/?#\[\]@!$&'\(\)*+,;=%\p{M}’]/, "")
 
       parsed = Addressable::URI.parse(url)
-      return "" unless parsed.host && parsed
+      return "" unless parsed.host
 
       url
     end

--- a/lib/onebox/helpers.rb
+++ b/lib/onebox/helpers.rb
@@ -178,6 +178,10 @@ module Onebox
       url.gsub!("'", "&apos;")
       url.gsub!('"', "&quot;")
       url.gsub!(/[^\w\-`.~:\/?#\[\]@!$&'\(\)*+,;=%\p{M}’]/, "")
+
+      parsed = Addressable::URI.parse(url)
+      return "" unless parsed.host && parsed
+
       url
     end
 

--- a/lib/onebox/open_graph.rb
+++ b/lib/onebox/open_graph.rb
@@ -32,8 +32,8 @@ module Onebox
       if method_name.end_with?(*integer_suffixes)
         value.to_i
       elsif method_name.end_with?(*url_suffixes)
-        result = ::Onebox::Helpers.normalize_url_for_output(value)
-        Onebox::Helpers::blank?(result) ? nil : result
+        result = Onebox::Helpers.normalize_url_for_output(value)
+        result unless Onebox::Helpers::blank?(result)
       else
         value
       end

--- a/lib/onebox/open_graph.rb
+++ b/lib/onebox/open_graph.rb
@@ -32,7 +32,8 @@ module Onebox
       if method_name.end_with?(*integer_suffixes)
         value.to_i
       elsif method_name.end_with?(*url_suffixes)
-        ::Onebox::Helpers.normalize_url_for_output(value)
+        result = ::Onebox::Helpers.normalize_url_for_output(value)
+        Onebox::Helpers::blank?(result) ? nil : result
       else
         value
       end

--- a/spec/lib/onebox/helpers_spec.rb
+++ b/spec/lib/onebox/helpers_spec.rb
@@ -134,6 +134,9 @@ RSpec.describe Onebox::Helpers do
     it { expect(described_class.normalize_url_for_output('http://example.com/fo"o')).to eq("http://example.com/fo&quot;o") }
     it { expect(described_class.normalize_url_for_output('http://example.com/fo<o>')).to eq("http://example.com/foo") }
     it { expect(described_class.normalize_url_for_output('http://example.com/d’écran-à')).to eq("http://example.com/d’écran-à") }
+    it { expect(described_class.normalize_url_for_output('//example.com/hello')).to eq("//example.com/hello") }
+    it { expect(described_class.normalize_url_for_output('example.com/hello')).to eq("") }
+    it { expect(described_class.normalize_url_for_output('linear-gradient(310.77deg, #29AA9F 0%, #098EA6 100%)')).to eq("") }
   end
 
   describe '.uri_encode' do


### PR DESCRIPTION
Attempt to validate the format of URLs for image and video attributes, and remove any values that appear to be invalid.