### PR TITLE
FIX: do not show title only oneboxes

### DIFF
--- a/lib/onebox/engine/allowlisted_generic_onebox.rb
+++ b/lib/onebox/engine/allowlisted_generic_onebox.rb
@@ -301,7 +301,8 @@ module Onebox
       end
 
       def has_text?
-        !Onebox::Helpers.blank?(data[:title])
+        !Onebox::Helpers.blank?(data[:title]) &&
+        !Onebox::Helpers.blank?(data[:description])
       end
 
       def is_image?

--- a/lib/onebox/version.rb
+++ b/lib/onebox/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Onebox
-  VERSION = "2.1.9"
+  VERSION = "2.2.0"
 end

--- a/spec/lib/onebox/engine/allowlisted_generic_onebox_spec.rb
+++ b/spec/lib/onebox/engine/allowlisted_generic_onebox_spec.rb
@@ -178,18 +178,15 @@ describe Onebox::Engine::AllowlistedGenericOnebox do
   end
 
   describe 'missing description' do
-    context 'works without description' do
+    context 'does not work without description' do
       let(:cnn_url) { "https://edition.cnn.com/2020/05/15/health/gallery/coronavirus-people-adopting-pets-photos/index.html" }
       before do
         fake(cnn_url, response('cnn'))
       end
 
-      it 'shows basic onebox' do
+      it 'does not onebox' do
         onebox = described_class.new(cnn_url)
-        expect(onebox.to_html).not_to be_nil
-        expect(onebox.to_html).to include("https://edition.cnn.com/2020/05/15/health/gallery/coronavirus-people-adopting-pets-photos/index.html")
-        expect(onebox.to_html).to include("https://cdn.cnn.com/cnnnext/dam/assets/200427093451-10-coronavirus-people-adopting-pets-super-tease.jpg")
-        expect(onebox.to_html).to include("People are fostering and adopting pets during the pandemic")
+        expect(onebox.to_html).to be_nil
       end
     end
   end


### PR DESCRIPTION
This commit prevents oneboxing of links that only has title in metadata.