### PR TITLE
DEV: Call `URI.open` explicitly

### DIFF
--- a/lib/onebox/engine/github_issue_onebox.rb
+++ b/lib/onebox/engine/github_issue_onebox.rb
@@ -22,8 +22,7 @@ module Onebox
       end
 
       def data
-
-        @raw ||= ::MultiJson.load(open(url, "Accept" => "application/vnd.github.v3.text+json", read_timeout: timeout)) #custom Accept header so we can get body as text.
+        @raw ||= ::MultiJson.load(URI.open(url, "Accept" => "application/vnd.github.v3.text+json", read_timeout: timeout)) #custom Accept header so we can get body as text.
         body_text = @raw["body_text"]
 
         content_words = body_text.gsub("\n\n", "\n").gsub("\n", "<br>").split(" ") #one pass of removing double newline, then we change \n to <br> and later on we revert it back to \n this is a workaround to avoid losing newlines after we join it back.

--- a/lib/onebox/engine/json.rb
+++ b/lib/onebox/engine/json.rb
@@ -6,7 +6,7 @@ module Onebox
       private
 
       def raw
-        @raw ||= ::MultiJson.load(open(url, read_timeout: timeout))
+        @raw ||= ::MultiJson.load(URI.open(url, read_timeout: timeout))
       end
     end
   end

--- a/lib/onebox/engine/pubmed_onebox.rb
+++ b/lib/onebox/engine/pubmed_onebox.rb
@@ -11,7 +11,7 @@ module Onebox
       private
 
       def get_xml
-        doc = Nokogiri::XML(open(URI.join(@url, "?report=xml&format=text")))
+        doc = Nokogiri::XML(URI.open(URI.join(@url, "?report=xml&format=text")))
         pre = doc.xpath("//pre")
         Nokogiri::XML("<root>" + pre.text + "</root>")
       end

--- a/lib/onebox/mixins/git_blob_onebox.rb
+++ b/lib/onebox/mixins/git_blob_onebox.rb
@@ -167,7 +167,7 @@ module Onebox
               @raw = "https://render.githubusercontent.com/view/solid?url=" + self.raw_template(m)
 
             else
-              contents = open(self.raw_template(m), read_timeout: timeout).read
+              contents = URI.open(self.raw_template(m), read_timeout: timeout).read
 
               contents_lines = contents.lines           #get contents lines
               contents_lines_size = contents_lines.size #get number of lines

--- a/lib/onebox/status_check.rb
+++ b/lib/onebox/status_check.rb
@@ -35,7 +35,7 @@ module Onebox
     private
 
     def check
-      res = open(@url, read_timeout: (@options.timeout || Onebox.options.timeout))
+      res = URI.open(@url, read_timeout: (@options.timeout || Onebox.options.timeout))
       @status = res.status.first.to_i
     rescue OpenURI::HTTPError => e
       @status = e.io.status.first.to_i


### PR DESCRIPTION
Makes the gem compatible with Ruby 3.