### PR TITLE
DEV: Remove default for disable_media_download_controls

### DIFF
--- a/lib/onebox.rb
+++ b/lib/onebox.rb
@@ -21,8 +21,7 @@ module Onebox
     allowed_ports: [80, 443],
     allowed_schemes: ["http", "https"],
     sanitize_config: Sanitize::Config::ONEBOX,
-    redirect_limit: 5,
-    disable_media_download_controls: false
+    redirect_limit: 5
   }
 
   @@options = DEFAULTS

--- a/lib/onebox/version.rb
+++ b/lib/onebox/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Onebox
-  VERSION = "2.2.5"
+  VERSION = "2.2.6"
 end


### PR DESCRIPTION
Not needed as per comments in https://github.com/discourse/onebox/pull/454