### PR TITLE
FIX: Update user agent used for Amazon requests

### DIFF
--- a/lib/onebox/engine/amazon_onebox.rb
+++ b/lib/onebox/engine/amazon_onebox.rb
@@ -28,7 +28,7 @@ module Onebox
       def http_params
         {
           'User-Agent' =>
-          'Mozilla/5.0 (iPhone; CPU iPhone OS 5_0_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A405 Safari/7534.48.3'
+          'Mozilla/5.0 (iPhone; CPU iPhone OS 12_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148'
         }
       end
 

--- a/lib/onebox/version.rb
+++ b/lib/onebox/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Onebox
-  VERSION = "2.2.6"
+  VERSION = "2.2.7"
 end


### PR DESCRIPTION
We use a custom user agent when making requests against various Amazon properties. However, the user agent is quite old which may be a cause of 503 errors that users are noticing when oneboxing Amazon URLs.

Updating this user agent to a current/more popular user agent may help avoid these errors.