### PR TITLE
DEV: Small Amazon fixes

### DIFF
--- a/lib/onebox/engine/amazon_onebox.rb
+++ b/lib/onebox/engine/amazon_onebox.rb
@@ -17,9 +17,9 @@ module Onebox
         # If possible, fetch the cached HTML body immediately so we can
         # try to grab the canonical URL from that document,
         # rather than guess at the best URL structure to use
-        if @body_cacher&.respond_to?('cache_response_body?')
-          if @body_cacher.cache_response_body?(uri.to_s) && @body_cacher.cached_response_body_exists?(uri.to_s)
-            @raw ||= Onebox::Helpers.fetch_html_doc(@url, http_params, @body_cacher)
+        if body_cacher&.respond_to?('cache_response_body?')
+          if body_cacher.cache_response_body?(uri.to_s) && body_cacher.cached_response_body_exists?(uri.to_s)
+            @raw ||= Onebox::Helpers.fetch_html_doc(@url, http_params, body_cacher)
           end
         end
 

--- a/lib/onebox/engine/amazon_onebox.rb
+++ b/lib/onebox/engine/amazon_onebox.rb
@@ -17,7 +17,7 @@ module Onebox
         # If possible, fetch the cached HTML body immediately so we can
         # try to grab the canonical URL from that document,
         # rather than guess at the best URL structure to use
-        if @body_cacher && @body_cacher.respond_to?('cache_response_body?')
+        if @body_cacher&.respond_to?('cache_response_body?')
           if @body_cacher.cache_response_body?(uri.to_s) && @body_cacher.cached_response_body_exists?(uri.to_s)
             @raw ||= Onebox::Helpers.fetch_html_doc(@url, http_params, @body_cacher)
           end
@@ -175,11 +175,8 @@ module Onebox
 
           summary = raw.at("#productDescription")
 
-          description = og.description || (summary && summary.inner_text)
-          description ||= begin
-            meta_description = raw.css("meta[name=description]")
-            meta_description.first["content"] if meta_description.length > 0
-          end
+          description = og.description || summary&.inner_text
+          description ||= raw.css("meta[name=description]").first&.[]("content")
           result[:description] = CGI.unescapeHTML(Onebox::Helpers.truncate(description, 250)) if description
         end
 

--- a/lib/onebox/engine/amazon_onebox.rb
+++ b/lib/onebox/engine/amazon_onebox.rb
@@ -23,7 +23,7 @@ module Onebox
           end
         end
 
-        if @raw.present?
+        if @raw
           canonical_link = @raw.at('//link[@rel="canonical"]/@href')
           return canonical_link.to_s if canonical_link
         end
@@ -174,8 +174,13 @@ module Onebox
           result[:by_info] = Onebox::Helpers.clean(result[:by_info].inner_html) if result[:by_info]
 
           summary = raw.at("#productDescription")
-          description = og.description || (summary && summary.inner_text) || raw.css("meta[name=description]").first["content"]
-          result[:description] = CGI.unescapeHTML(Onebox::Helpers.truncate(description, 250))
+
+          description = og.description || (summary && summary.inner_text)
+          description ||= begin
+            meta_description = raw.css("meta[name=description]")
+            meta_description.first["content"] if meta_description.length > 0
+          end
+          result[:description] = CGI.unescapeHTML(Onebox::Helpers.truncate(description, 250)) if description
         end
 
         result[:price] = nil if result[:price].start_with?("$0") || result[:price] == 0

--- a/lib/onebox/engine/amazon_onebox.rb
+++ b/lib/onebox/engine/amazon_onebox.rb
@@ -175,7 +175,8 @@ module Onebox
           result[:by_info] = Onebox::Helpers.clean(result[:by_info].inner_html) if result[:by_info]
 
           summary = raw.at("#productDescription")
-          result[:description] = og.description || (summary && summary.inner_text) || CGI.unescapeHTML(Onebox::Helpers.truncate(raw.css("meta[name=description]").first["content"], 250))
+          description = og.description || (summary && summary.inner_text) || raw.css("meta[name=description]").first["content"]
+          result[:description] = CGI.unescapeHTML(Onebox::Helpers.truncate(description, 250))
         end
 
         result[:price] = nil if result[:price].start_with?("$0") || result[:price] == 0

--- a/lib/onebox/engine/amazon_onebox.rb
+++ b/lib/onebox/engine/amazon_onebox.rb
@@ -45,7 +45,11 @@ module Onebox
       private
 
       def match
-        @match ||= @url.match(/(?:d|g)p\/(?:product\/|video\/detail\/)?(?<id>[^\/]+)(?:\/|$)/mi)
+        @match ||= @url.match(/(?:d|g)p\/(?:product\/|video\/detail\/)?(?<id>[A-Z0-9]+)(?:\/|\?|$)/mi)
+      end
+
+      def link
+        @link ||= ::Onebox::Helpers.uri_encode(url)
       end
 
       def image
@@ -60,6 +64,10 @@ module Onebox
         end
 
         if (landing_image = raw.css("#landingImage")) && landing_image.any?
+          attributes = landing_image.first.attributes
+
+          return attributes["data-old-hires"].to_s if attributes["data-old-hires"]
+
           landing_image.first["src"].to_s
         end
 
@@ -110,7 +118,7 @@ module Onebox
           end
 
           result = {
-            link: link,
+            link: url,
             title: title,
             by_info: authors,
             image: og.image || image,
@@ -141,7 +149,7 @@ module Onebox
           end
 
           result = {
-            link: link,
+            link: url,
             title: title,
             by_info: authors,
             image: og.image || image,
@@ -157,7 +165,7 @@ module Onebox
         else
           title = og.title || CGI.unescapeHTML(raw.css("title").inner_text)
           result = {
-            link: link,
+            link: url,
             title: title,
             image: og.image || image,
             price: price

--- a/lib/onebox/engine/html.rb
+++ b/lib/onebox/engine/html.rb
@@ -11,8 +11,11 @@ module Onebox
       end
 
       def raw
-        @body_cacher = self.options[:body_cacher] if self.options
-        @raw ||= Onebox::Helpers.fetch_html_doc(url, http_params, @body_cacher)
+        @raw ||= Onebox::Helpers.fetch_html_doc(url, http_params, body_cacher)
+      end
+
+      def body_cacher
+        self.options&.[](:body_cacher)
       end
 
       def html?

--- a/lib/onebox/engine/html.rb
+++ b/lib/onebox/engine/html.rb
@@ -11,8 +11,8 @@ module Onebox
       end
 
       def raw
-        body_cacher = self.options[:body_cacher] if self.options
-        @raw ||= Onebox::Helpers.fetch_html_doc(url, http_params, body_cacher)
+        @body_cacher = self.options[:body_cacher] if self.options
+        @raw ||= Onebox::Helpers.fetch_html_doc(url, http_params, @body_cacher)
       end
 
       def html?

--- a/lib/onebox/version.rb
+++ b/lib/onebox/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Onebox
-  VERSION = "2.2.9"
+  VERSION = "2.2.10"
 end

--- a/spec/lib/onebox/engine/amazon_onebox_spec.rb
+++ b/spec/lib/onebox/engine/amazon_onebox_spec.rb
@@ -98,10 +98,6 @@ describe Onebox::Engine::AmazonOnebox do
       it "includes title" do
         expect(html).to include("Seven Languages in Seven Weeks: A Pragmatic Guide to Learning Programming Languages (Pragmatic Programmers)")
       end
-
-      it "includes canonical link" do
-        expect(html).to include(@uri)
-      end
     end
   end
 

--- a/spec/lib/onebox/engine/amazon_onebox_spec.rb
+++ b/spec/lib/onebox/engine/amazon_onebox_spec.rb
@@ -73,6 +73,13 @@ describe Onebox::Engine::AmazonOnebox do
         expect(described_class.new("http://www.amazon.fr/gp/product/B01BYD0TZM").url)
           .to eq("https://www.amazon.fr/dp/B01BYD0TZM")
       end
+
+      let(:long_url) { "https://www.amazon.ca/gp/product/B087Z3N428?pf_rd_r=SXABADD0ZZ3NF9Q5F8TW&pf_rd_p=05378fd5-c43e-4948-99b1-a65b129fdd73&pd_rd_r=0237fb28-7f47-49f4-986a-be0c78e52863&pd_rd_w=FfIoI&pd_rd_wg=Hw4qq&ref_=pd_gw_unk" }
+
+      it "removes parameters from the URL" do
+        expect(described_class.new(long_url).url)
+          .not_to include("?pf_rd_r")
+      end
     end
 
     describe "#to_html" do
@@ -90,6 +97,10 @@ describe Onebox::Engine::AmazonOnebox do
 
       it "includes title" do
         expect(html).to include("Seven Languages in Seven Weeks: A Pragmatic Guide to Learning Programming Languages (Pragmatic Programmers)")
+      end
+
+      it "includes canonical link" do
+        expect(html).to include(@uri)
       end
     end
   end


### PR DESCRIPTION
* Use the canonical URL as the link within the generated onebox

* Use the `data-old-hires` value for the image URL, if available

* Version bump to 2.2.10