### PR TITLE
UX: display long PRs/Issues in an expandable excerpt

### DIFF
--- a/lib/onebox/engine/github_issue_onebox.rb
+++ b/lib/onebox/engine/github_issue_onebox.rb
@@ -26,27 +26,26 @@ module Onebox
       end
 
       def data
-        @raw ||= ::MultiJson.load(URI.open(url, "Accept" => "application/vnd.github.v3.raw+json", read_timeout: timeout)) #custom Accept header so we can get body as text.
-        created_at = Time.parse(@raw['created_at'])
-        closed_at = Time.parse(@raw['closed_at']) if @raw['closed_at']
-        body, excerpt = compute_body(@raw['body'])
+        created_at = Time.parse(raw['created_at'])
+        closed_at = Time.parse(raw['closed_at']) if raw['closed_at']
+        body, excerpt = compute_body(raw['body'])
         ulink = URI(link)
 
         {
           link: @url,
-          title: @raw["title"],
+          title: raw["title"],
           body: body,
           excerpt: excerpt,
-          labels: @raw["labels"],
-          user: @raw['user'],
+          labels: raw["labels"],
+          user: raw['user'],
           created_at: created_at.strftime("%I:%M%p - %d %b %y %Z"),
           created_at_date: created_at.strftime("%F"),
           created_at_time: created_at.strftime("%T"),
           closed_at: closed_at&.strftime("%I:%M%p - %d %b %y %Z"),
           closed_at_date: closed_at&.strftime("%F"),
           closed_at_time: closed_at&.strftime("%T"),
-          closed_by: @raw['closed_by'],
-          avatar: "https://avatars1.githubusercontent.com/u/#{@raw['user']['id']}?v=2&s=96",
+          closed_by: raw['closed_by'],
+          avatar: "https://avatars1.githubusercontent.com/u/#{raw['user']['id']}?v=2&s=96",
           domain: "#{ulink.host}/#{ulink.path.split('/')[1]}/#{ulink.path.split('/')[2]}",
         }
       end

--- a/lib/onebox/mixins/github_body.rb
+++ b/lib/onebox/mixins/github_body.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Onebox
+  module Mixins
+    module GithubBody
+      def self.included(klass)
+        klass.include(Onebox::Engine)
+        klass.include(InstanceMethods)
+      end
+
+      module InstanceMethods
+        GITHUB_COMMENT_REGEX = /(<!--.*?-->\r\n)/
+        MAX_BODY_LENGTH = 80
+        def compute_body(body)
+          body = body.dup
+          excerpt = nil
+
+          body = (body || '').gsub(GITHUB_COMMENT_REGEX, '')
+          body = body.length > 0 ? body : nil
+          if body && body.length > MAX_BODY_LENGTH
+            excerpt = body[MAX_BODY_LENGTH..body.length].rstrip
+            body = body[0..MAX_BODY_LENGTH - 1].rstrip
+          end
+
+          [body, excerpt]
+        end
+      end
+    end
+  end
+end

--- a/lib/onebox/mixins/github_body.rb
+++ b/lib/onebox/mixins/github_body.rb
@@ -19,7 +19,7 @@ module Onebox
           body = body.length > 0 ? body : nil
           if body && body.length > MAX_BODY_LENGTH
             excerpt = body[MAX_BODY_LENGTH..body.length].rstrip
-            body = body[0..MAX_BODY_LENGTH - 1].rstrip
+            body = body[0..MAX_BODY_LENGTH - 1]
           end
 
           [body, excerpt]

--- a/lib/onebox/version.rb
+++ b/lib/onebox/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Onebox
-  VERSION = "2.2.12"
+  VERSION = "2.2.13"
 end

--- a/templates/github/github_body.mustache
+++ b/templates/github/github_body.mustache
@@ -1,0 +1,3 @@
+{{#body}}
+  <p class="github-body-container">{{body}}{{#excerpt}}<span class="show-more-container"><a href="{{html_url}}" target="_blank" rel="noopener" class="show-more">…</a>{{/excerpt}}</span>{{#excerpt}}<span class="excerpt hidden">{{excerpt}}</span>{{/excerpt}}</p>
+{{/body}}

--- a/templates/githubissue.mustache
+++ b/templates/githubissue.mustache
@@ -26,15 +26,13 @@
         </a>
       </div>
     </div>
+
+    {{> github/github_body}}
+
+    <div class='labels'>
+      {{#labels}}
+        <span style="display:inline-block;margin-top:2px;background-color: #B8B8B8;padding: 2px;border-radius: 4px;color: #fff;margin-left: 3px;">{{name}}</span>
+      {{/labels}}
+    </div>
   </div>
-</div>
-
-<div class="github-row">
-  <p class='github-content'>{{content}}</p>
-</div>
-
-<div class='labels'>
-  {{#labels}}
-    <span style="display:inline-block;margin-top:2px;background-color: #B8B8B8;padding: 2px;border-radius: 4px;color: #fff;margin-left: 3px;">{{name}}</span>
-  {{/labels}}
 </div>

--- a/templates/githubpullrequest.mustache
+++ b/templates/githubpullrequest.mustache
@@ -4,22 +4,9 @@
   </div>
 
   <div class="github-info-container">
-    {{^body}}
-      <h4>
-        <a href="{{html_url}}" target="_blank" rel="noopener">{{title}}</a>
-      </h4>
-    {{/body}}
-
-    {{#body}}
-      <details class="onebox-details">
-        <summary class="onebox-details-summary">
-          <h4>
-            <a href="{{html_url}}" target="_blank" rel="noopener">{{title}}</a>
-          </h4>
-        </summary>
-        <p class="onebox-details-body">{{body}}</p>
-      </details>
-    {{/body}}
+    <h4>
+      <a href="{{html_url}}" target="_blank" rel="noopener">{{title}}</a>
+    </h4>
 
     <div class="branches">
       <code>{{base.label}}</code> ← <code>{{head.label}}</code>
@@ -45,5 +32,6 @@
       </div>
     </div>
 
+    {{> github/github_body}}
   </div>
 </div>


### PR DESCRIPTION
Note that this PR is also slightly changing github issues body position, and is using raw instead of text in the API call to get the raw body of the issue instead of a text only version.

This PR needs a companion PR in discourse core for the JS behavior: https://github.com/discourse/discourse/pull/12698