### PR TITLE
FIX: Follow additional redirect status codes

### DIFF
--- a/lib/onebox/helpers.rb
+++ b/lib/onebox/helpers.rb
@@ -90,7 +90,8 @@ module Onebox
 
           code = response.code.to_i
           unless code === 200
-            response.error! unless [301, 302].include?(code)
+            response.error! unless [301, 302, 303, 307, 308].include?(code)
+
             return fetch_response(
               response['location'],
               redirect_limit: redirect_limit - 1,

--- a/lib/onebox/version.rb
+++ b/lib/onebox/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Onebox
-  VERSION = "2.2.14"
+  VERSION = "2.2.15"
 end

--- a/spec/lib/onebox/helpers_spec.rb
+++ b/spec/lib/onebox/helpers_spec.rb
@@ -56,8 +56,10 @@ RSpec.describe Onebox::Helpers do
   describe "redirects" do
     describe "redirect limit" do
       before do
+        codes = [301, 302, 303, 307, 308]
         (1..6).each do |i|
-          FakeWeb.register_uri(:get, "https://httpbin.org/redirect/#{i}", location: "https://httpbin.org/redirect/#{i - 1}", body: "", status: [302, "Found"])
+          code = codes.pop || 302
+          FakeWeb.register_uri(:get, "https://httpbin.org/redirect/#{i}", location: "https://httpbin.org/redirect/#{i - 1}", body: "", status: [code, "Found"])
         end
         fake("https://httpbin.org/redirect/0", "<!DOCTYPE html><p>success</p>")
       end


### PR DESCRIPTION
Don’t throw errors if we encounter 303, 307 or 308 HTTP status codes in responses