### PR TITLE
let the vimeo engine use the returned oembed html instead of constructing an own iframe

### DIFF
--- a/lib/onebox/engine/vimeo_onebox.rb
+++ b/lib/onebox/engine/vimeo_onebox.rb
@@ -18,11 +18,13 @@ module Onebox
       end
 
       def to_html
-        video_id = oembed_data[:video_id]
-        if video_id.nil?
-          # for private videos
-          video_id = uri.path[/\/(\d+)/, 1]
-        end
+        oembed = oembed_data
+
+        return oembed[:html] if oembed[:html]
+
+        # for private videos
+        video_id = oembed[:video_id] || uri.path[/\/(\d+)/, 1]
+
         video_src = "https://player.vimeo.com/video/#{video_id}"
         video_src = video_src.gsub('autoplay=1', '').chomp("?")
 


### PR DESCRIPTION
I do not know why, but instead of using the HTML returned by Vimeo's OEmbed API response, Onebox constructs it's own HTML. Resulting in some videos to be rendered as this:
![image](https://user-images.githubusercontent.com/140655/133767514-a09ba15e-ad17-4450-a319-c3fd1ac1657e.png)

The OEmbed API does return correct HTML, however, so I prefer to use that instead.

(I'm sorry but as the video, that was shown as such, is private I can not share the URI for it)