### PR TITLE
Update Replit embeds to use replit.com

### DIFF
--- a/lib/onebox/engine/replit_onebox.rb
+++ b/lib/onebox/engine/replit_onebox.rb
@@ -6,7 +6,7 @@ module Onebox
       include Engine
       include StandardEmbed
 
-      matches_regexp(/^https?:\/\/repl\.it\/.+/)
+      matches_regexp(/^https?:\/\/(replit\.com|repl\.it)\/.+/)
       always_https
 
       def placeholder_html


### PR DESCRIPTION
[Replit moved from `repl.it` to `replit.com`](https://blog.replit.com/dotcom). `repl.it` redirects to `replit.com` so old links should still work.

See preview here:
https://onebox-replit-dotcom.masfrost.repl.co/?url=https://replit.com/@masfrost/onebox-replit-dotcom

![image](https://user-images.githubusercontent.com/1994028/137410639-e546bebb-0108-435c-b6dd-a6f736946098.png)


